### PR TITLE
ci: adiciona pipelines de CI, CodeQL e SonarQube Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: "9.0.x"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Verificar formatação (dotnet format)
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+        continue-on-error: true
+        # continue-on-error: true por enquanto — troque para "false" quando
+        # o time estiver confortável com o gate de formatação bloqueando PRs.
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: >
+          dotnet test --no-build --configuration Release
+          --logger "trx;LogFileName=test-results.trx"
+          --collect:"XPlat Code Coverage"
+          --results-directory ./TestResults
+
+      - name: Publicar resultados de teste
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results
+          path: ./TestResults

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # roda toda segunda-feira às 08:00 UTC, além dos push/PR acima
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: autobuild
+          # Se o autobuild falhar (comum em soluções .NET com múltiplos
+          # projetos/target frameworks), troque para build-mode: manual
+          # e adicione steps de "dotnet build" explícitos aqui embaixo.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,84 @@
+name: SonarQube Cloud
+
+# Secrets necessários neste repositório (Settings > Secrets and variables > Actions):
+#   SONAR_TOKEN -> token gerado no SonarQube Cloud (My Account > Security)
+#
+# Projeto/organização já configurados no SonarQube Cloud:
+#   organization: arielm11
+#   projectKey:   arielm11_SIGA-TCC
+#
+# Cobertura: o projeto usa coverlet.collector (via --collect:"XPlat Code
+# Coverage"), não coverlet.msbuild — por isso a coleta abaixo força o
+# formato OpenCover via runsettings inline, em vez de /p:CollectCoverage=true
+# (que só funciona com coverlet.msbuild).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: "9.0.x" # mesmo valor usado no ci.yml — mantenha sincronizado
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # necessário para o Sonar calcular blame/histórico corretamente
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Java (requerido pelo scanner do Sonar)
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Cache do SonarQube scanner
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Instalar dotnet-sonarscanner
+        run: dotnet tool install --global dotnet-sonarscanner --version 11.2.0
+
+      - name: Iniciar análise Sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          dotnet sonarscanner begin
+          /k:"arielm11_SIGA-TCC"
+          /o:"arielm11"
+          /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.host.url="https://sonarcloud.io"
+          /d:sonar.cs.vstest.reportsPaths="**/*.trx"
+          /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test com cobertura
+        run: >
+          dotnet test --no-restore --configuration Release
+          --logger "trx"
+          --collect:"XPlat Code Coverage"
+          --results-directory ./TestResults
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+
+      - name: Finalizar análise Sonar
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
## Summary
- Adiciona workflow de CI (build + test em push/PR para `main`, com publicação de resultados de teste)
- Adiciona workflow do CodeQL (análise estática de segurança para C#, em push/PR e semanalmente)
- Adiciona workflow do SonarQube Cloud (análise de qualidade de código, organization `arielm11` / project `arielm11_SIGA-TCC`)

Ajustes feitos em relação aos templates originais:
- `DOTNET_VERSION` corrigido para `9.0.x` (versão real do projeto)
- Versões de actions atualizadas (`checkout@v6`, `setup-dotnet@v5`, `setup-java@v5`, `upload-artifact@v7`)
- Coleta de cobertura padronizada via `coverlet.collector` (já instalado no projeto), com formato OpenCover forçado via runsettings inline para o Sonar — o template original assumia `coverlet.msbuild`, que não está no projeto

## Test plan
- [ ] Confirmar que o secret `SONAR_TOKEN` está configurado no repositório (já configurado)
- [ ] Verificar que o job `CI` passa (build + testes) após o merge/abertura do PR
- [ ] Verificar que o job `CodeQL` completa a análise sem falha de `autobuild`
- [ ] Verificar que o job `SonarQube Cloud` publica o resultado no dashboard do SonarCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)