### PR TITLE
fix: correções de segurança e observabilidade (S1-S4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@
 appsettings.Local.json
 appsettings.Development.json
 
+# Serilog file sink output
+TccManager.Api/Logs/
+
+# Claude file output
+docs/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/TccManager.Api/Configuration/EmailSetup.cs
+++ b/TccManager.Api/Configuration/EmailSetup.cs
@@ -1,0 +1,26 @@
+using TccManager.Api.Services.Email;
+using TccManager.Api.Services.Notifications;
+
+namespace TccManager.Api.Configuration;
+
+/// <summary>
+/// Registro em DI do subsistema de notificações por e-mail (N1). Segue o mesmo padrão de
+/// extensão estática já usado em RateLimitingSetup. Config lida da seção "Email" (host,
+/// porta, usuário, senha e remetente via User Secrets em desenvolvimento — ver appsettings.json).
+/// </summary>
+public static class EmailSetup
+{
+    public static IServiceCollection AddEmailNotifications(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<EmailSettings>(configuration.GetSection("Email"));
+
+        services.AddSingleton<IEmailQueue, ChannelEmailQueue>();
+        services.AddSingleton<IEmailService, MailKitEmailService>();
+        services.AddSingleton<IEmailTemplateRenderer, FileEmailTemplateRenderer>();
+        services.AddHostedService<EmailBackgroundService>();
+
+        services.AddScoped<ITccNotificationService, TccNotificationService>();
+
+        return services;
+    }
+}

--- a/TccManager.Api/Configuration/LoggingSetup.cs
+++ b/TccManager.Api/Configuration/LoggingSetup.cs
@@ -1,0 +1,37 @@
+using Serilog;
+using TccManager.Api.Logging;
+
+namespace TccManager.Api.Configuration;
+
+/// <summary>
+/// Configuração do Serilog em dois estágios: um bootstrap logger (apenas console),
+/// usado antes do host existir para capturar falhas de inicialização, e o logger
+/// definitivo, lido a partir do appsettings (RNF3).
+/// </summary>
+public static class LoggingSetup
+{
+    public static void CreateBootstrapLogger()
+    {
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Console()
+            .CreateBootstrapLogger();
+    }
+
+    public static WebApplicationBuilder ConfigureLogging(this WebApplicationBuilder builder)
+    {
+        // preserveStaticLogger: true evita que o logger definitivo (por host) dispute e
+        // "congele" o mesmo Log.Logger estático global usado pelo bootstrap — relevante
+        // porque múltiplas instâncias de WebApplicationFactory<Program> no mesmo processo
+        // (testes de integração) criam múltiplos hosts na mesma execução.
+        builder.Host.UseSerilog((context, services, configuration) =>
+        {
+            configuration
+                .ReadFrom.Configuration(context.Configuration)
+                .ReadFrom.Services(services)
+                .Destructure.With<SensitiveDataMaskingPolicy>();
+        }, preserveStaticLogger: true);
+
+        return builder;
+    }
+}

--- a/TccManager.Api/Configuration/RateLimitingSetup.cs
+++ b/TccManager.Api/Configuration/RateLimitingSetup.cs
@@ -1,0 +1,65 @@
+using System.Globalization;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace TccManager.Api.Configuration;
+
+/// <summary>
+/// Política de rate limiting nomeada "login": FixedWindowLimiter, particionado por
+/// IP do cliente (Connection.RemoteIpAddress — ambiente é localhost-only, sem proxy
+/// reverso, portanto não há tratamento de ForwardedHeaders/X-Forwarded-For).
+/// </summary>
+public static class RateLimitingSetup
+{
+    public const string LoginPolicyName = "login";
+
+    public static IServiceCollection ConfigureRateLimiting(this IServiceCollection services, IConfiguration configuration)
+    {
+        var permitLimit = configuration.GetValue<int?>("RateLimiting:Login:PermitLimit") ?? 5;
+        var windowSeconds = configuration.GetValue<int?>("RateLimiting:Login:WindowSeconds") ?? 60;
+        var queueLimit = configuration.GetValue<int?>("RateLimiting:Login:QueueLimit") ?? 0;
+
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            options.AddPolicy(LoginPolicyName, context =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = permitLimit,
+                        Window = TimeSpan.FromSeconds(windowSeconds),
+                        QueueLimit = queueLimit
+                    }));
+
+            options.OnRejected = (context, cancellationToken) =>
+            {
+                var httpContext = context.HttpContext;
+
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                {
+                    httpContext.Response.Headers.RetryAfter =
+                        ((int)retryAfter.TotalSeconds).ToString(NumberFormatInfo.InvariantInfo);
+                }
+
+                var remoteIp = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                // Logger obtido via DI (não Serilog.Log estático) para respeitar o logger
+                // configurado por host (ver LoggingSetup, preserveStaticLogger: true).
+                var logger = httpContext.RequestServices
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("TccManager.Api.RateLimiting");
+
+                logger.LogWarning(
+                    "Tentativa de login bloqueada por rate limiting. IP de origem: {RemoteIp}, Rota: {RequestPath}",
+                    remoteIp,
+                    httpContext.Request.Path.Value);
+
+                return ValueTask.CompletedTask;
+            };
+        });
+
+        return services;
+    }
+}

--- a/TccManager.Api/Controllers/AuthController.cs
+++ b/TccManager.Api/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
@@ -25,6 +26,7 @@ public class AuthController : ControllerBase
 
 
     [HttpPost("login")]
+    [EnableRateLimiting("login")]
     public async Task<IActionResult> Login([FromBody] LoginDto dto)
     {
         var usuario = await _context.Usuarios
@@ -38,8 +40,8 @@ public class AuthController : ControllerBase
 
         var token = GerarTokenJtw(usuario);
 
-        return Ok(new LoginResponseDto 
-        { 
+        return Ok(new LoginResponseDto
+        {
             Token = token,
             Nome = usuario.Nome,
             Email = usuario.Email

--- a/TccManager.Api/Controllers/AuthController.cs
+++ b/TccManager.Api/Controllers/AuthController.cs
@@ -1,13 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using TccManager.Api.Data;
+using TccManager.Api.Services.Auth;
 using TccManager.Shared.DTOs;
-using TccManager.Shared.Models;
 
 namespace TccManager.Api.Controllers;
 
@@ -16,16 +13,16 @@ namespace TccManager.Api.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly AppDbContext _context;
-    private readonly IConfiguration _configuration;
+    private readonly IAuthTokenService _authTokenService;
 
-    public AuthController(AppDbContext context, IConfiguration configuration)
+    public AuthController(AppDbContext context, IAuthTokenService authTokenService)
     {
         _context = context;
-        _configuration = configuration;
+        _authTokenService = authTokenService;
     }
 
-
     [HttpPost("login")]
+    [AllowAnonymous]
     [EnableRateLimiting("login")]
     public async Task<IActionResult> Login([FromBody] LoginDto dto)
     {
@@ -38,38 +35,41 @@ public class AuthController : ControllerBase
         if (!usuario.Ativo)
             return Unauthorized("Usuário inativo.");
 
-        var token = GerarTokenJtw(usuario);
+        var par = await _authTokenService.LoginAsync(usuario);
 
         return Ok(new LoginResponseDto
         {
-            Token = token,
+            Token = par.Token,
+            RefreshToken = par.RefreshToken,
             Nome = usuario.Nome,
             Email = usuario.Email
         });
     }
 
-    private string GerarTokenJtw(Usuario usuario)
+    [HttpPost("refresh")]
+    [AllowAnonymous]
+    [EnableRateLimiting("login")]
+    public async Task<IActionResult> Refresh([FromBody] RefreshRequestDto dto)
     {
-        var key = Encoding.ASCII.GetBytes(_configuration["Jwt:Key"]!);
-        var claims = new[]
-        {
-            new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString()),
-            new Claim(ClaimTypes.Name, usuario.Nome),
-            new Claim(ClaimTypes.Email, usuario.Email),
-            new Claim(ClaimTypes.Role, usuario.Tipo.ToString())
-        };
+        if (string.IsNullOrWhiteSpace(dto.RefreshToken))
+            return Unauthorized();
 
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity(claims),
-            Expires = DateTime.UtcNow.AddHours(1),
-            Issuer = _configuration["Jwt:Issuer"],
-            Audience = _configuration["Jwt:Audience"],
-            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
-        };
+        var par = await _authTokenService.RefreshAsync(dto.RefreshToken);
 
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        return tokenHandler.WriteToken(token);
+        if (par == null)
+            return Unauthorized();
+
+        return Ok(par);
+    }
+
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    [EnableRateLimiting("login")]
+    public async Task<IActionResult> Logout([FromBody] LogoutRequestDto dto)
+    {
+        if (!string.IsNullOrWhiteSpace(dto.RefreshToken))
+            await _authTokenService.LogoutAsync(dto.RefreshToken);
+
+        return NoContent();
     }
 }

--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -15,11 +15,13 @@ namespace TccManager.Api.Controllers;
 public class CoordenadorController : ControllerBase
 {
     private readonly AppDbContext _context;
+    private readonly ISanitizerService _sanitizerService;
     private const decimal notaMinimaAprovacao = 60.0m;
 
-    public CoordenadorController(AppDbContext context)
+    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService)
     {
         _context = context;
+        _sanitizerService = sanitizerService;
     }
 
     [HttpGet("dashboard-stats")]
@@ -261,7 +263,7 @@ public class CoordenadorController : ControllerBase
         else
         {
             banca.Tcc.Status = StatusTcc.Reprovado;
-            banca.Tcc.MotivoRejeicao = motivoReprovacao;
+            banca.Tcc.MotivoRejeicao = _sanitizerService.Sanitizar(motivoReprovacao);
         }
 
         await _context.SaveChangesAsync();

--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
 using TccManager.Api.Services;
+using TccManager.Api.Services.Notifications;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
@@ -16,12 +17,14 @@ public class CoordenadorController : ControllerBase
 {
     private readonly AppDbContext _context;
     private readonly ISanitizerService _sanitizerService;
+    private readonly ITccNotificationService _notificationService;
     private const decimal notaMinimaAprovacao = 60.0m;
 
-    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService)
+    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService)
     {
         _context = context;
         _sanitizerService = sanitizerService;
+        _notificationService = notificationService;
     }
 
     [HttpGet("dashboard-stats")]
@@ -88,6 +91,10 @@ public class CoordenadorController : ControllerBase
         tcc.Status = StatusTcc.Aprovado;
 
         await _context.SaveChangesAsync();
+
+        // Mesmo evento/template de OrientadorController.AprovarProposta (RF7).
+        await _notificationService.NotificarPropostaAprovadaAsync(tcc.Id);
+
         return Ok("Orientador designado com sucesso.");
     }
 
@@ -180,6 +187,11 @@ public class CoordenadorController : ControllerBase
         }
 
         await _context.SaveChangesAsync();
+
+        // Disparo após o SaveChanges que persiste os BancaAvaliador, para que a lista
+        // de avaliadores já esteja completa na resolução de destinatários (RF9).
+        await _notificationService.NotificarBancaAgendadaAsync(banca.Id);
+
         return Ok("Banca agendada com sucesso!");
     }
 
@@ -267,6 +279,8 @@ public class CoordenadorController : ControllerBase
         }
 
         await _context.SaveChangesAsync();
+
+        await _notificationService.NotificarResultadoBancaAsync(banca.Id, aprovado);
 
         var mensagem = aprovado
             ? "Resultado da banca registrado com sucesso! O TCC foi finalizado."

--- a/TccManager.Api/Controllers/OrientadorController.cs
+++ b/TccManager.Api/Controllers/OrientadorController.cs
@@ -16,10 +16,12 @@ namespace TccManager.Api.Controllers;
 public class OrientadorController : ControllerBase
 {
     private readonly AppDbContext _context;
+    private readonly ISanitizerService _sanitizerService;
 
-    public OrientadorController(AppDbContext context)
+    public OrientadorController(AppDbContext context, ISanitizerService sanitizerService)
     {
         _context = context;
+        _sanitizerService = sanitizerService;
     }
 
     [HttpGet("dashboard")]
@@ -94,7 +96,7 @@ public class OrientadorController : ControllerBase
         if (tcc == null) return NotFound("Proposta não encontrada ou já avaliada.");
 
         tcc.Status = StatusTcc.Reprovado;
-        tcc.MotivoRejeicao = dto.Motivo;
+        tcc.MotivoRejeicao = _sanitizerService.Sanitizar(dto.Motivo);
 
         await _context.SaveChangesAsync();
         return Ok("Proposta rejeitada.");
@@ -131,7 +133,7 @@ public class OrientadorController : ControllerBase
 
         if (entrega == null) return NotFound("Entrega não encontrada ou você não tem permissão para acessar.");
 
-        entrega.Feedback = dto.Feedback;
+        entrega.Feedback = _sanitizerService.Sanitizar(dto.Feedback);
         entrega.Nota = dto.Nota;
 
         await _context.SaveChangesAsync();
@@ -153,7 +155,7 @@ public class OrientadorController : ControllerBase
         {
             TccId = idTcc,
             DataReuniao = BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dto.DataReuniao),
-            Ata = dto.Ata
+            Ata = _sanitizerService.Sanitizar(dto.Ata)!
         };
 
         _context.Acompanhamentos.Add(novoAcompanhamento);
@@ -176,7 +178,7 @@ public class OrientadorController : ControllerBase
         if (acompanhamento == null) return NotFound("Acompanhamento não encontrado ou sem permissão.");
 
         acompanhamento.DataReuniao = BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dto.DataReuniao);
-        acompanhamento.Ata = dto.Ata;
+        acompanhamento.Ata = _sanitizerService.Sanitizar(dto.Ata)!;
 
         await _context.SaveChangesAsync();
         return Ok("Acompanhamento atualizado com sucesso.");

--- a/TccManager.Api/Controllers/OrientadorController.cs
+++ b/TccManager.Api/Controllers/OrientadorController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using TccManager.Api.Data;
 using TccManager.Api.Services;
+using TccManager.Api.Services.Notifications;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
@@ -17,11 +18,13 @@ public class OrientadorController : ControllerBase
 {
     private readonly AppDbContext _context;
     private readonly ISanitizerService _sanitizerService;
+    private readonly ITccNotificationService _notificationService;
 
-    public OrientadorController(AppDbContext context, ISanitizerService sanitizerService)
+    public OrientadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService)
     {
         _context = context;
         _sanitizerService = sanitizerService;
+        _notificationService = notificationService;
     }
 
     [HttpGet("dashboard")]
@@ -81,6 +84,9 @@ public class OrientadorController : ControllerBase
         tcc.OrientadorId = profId;
 
         await _context.SaveChangesAsync();
+
+        await _notificationService.NotificarPropostaAprovadaAsync(tcc.Id);
+
         return Ok("Proposta enviada com sucesso!");
     }
 
@@ -99,6 +105,9 @@ public class OrientadorController : ControllerBase
         tcc.MotivoRejeicao = _sanitizerService.Sanitizar(dto.Motivo);
 
         await _context.SaveChangesAsync();
+
+        await _notificationService.NotificarPropostaRejeitadaAsync(tcc.Id);
+
         return Ok("Proposta rejeitada.");
     }
 
@@ -137,6 +146,8 @@ public class OrientadorController : ControllerBase
         entrega.Nota = dto.Nota;
 
         await _context.SaveChangesAsync();
+
+        await _notificationService.NotificarFeedbackRegistradoAsync(entrega.Id);
 
         return Ok("Feedback registrado com sucesso.");
     }
@@ -221,6 +232,8 @@ public class OrientadorController : ControllerBase
 
         tcc.Status = StatusTcc.AguardandoDefesa;
         await _context.SaveChangesAsync();
+
+        await _notificationService.NotificarAceiteFinalAsync(tcc.Id);
 
         return Ok("Aceite final registrado com sucesso. O TCC agora aguarda o agendamento da Banca.");
     }

--- a/TccManager.Api/Controllers/TccController.cs
+++ b/TccManager.Api/Controllers/TccController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
+using TccManager.Api.Services;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
@@ -16,11 +17,13 @@ public class TccController : ControllerBase
 {
     private readonly AppDbContext _context;
     private readonly IWebHostEnvironment _environment;
+    private readonly ISanitizerService _sanitizerService;
 
-    public TccController(AppDbContext context, IWebHostEnvironment environment)
+    public TccController(AppDbContext context, IWebHostEnvironment environment, ISanitizerService sanitizerService)
     {
         _context = context;
         _environment = environment;
+        _sanitizerService = sanitizerService;
     }
 
     [HttpGet("meu-tcc")]
@@ -57,8 +60,8 @@ public class TccController : ControllerBase
 
         var tcc = new Tcc
         {
-            Titulo = dto.Titulo,
-            Resumo = dto.Resumo,
+            Titulo = _sanitizerService.Sanitizar(dto.Titulo)!,
+            Resumo = _sanitizerService.Sanitizar(dto.Resumo)!,
             AlunoId = alunoId,
             Status = StatusTcc.Pendente,
             DataCriacao = DateTime.UtcNow

--- a/TccManager.Api/Data/AppDbContext.cs
+++ b/TccManager.Api/Data/AppDbContext.cs
@@ -16,6 +16,7 @@ public class AppDbContext : DbContext
     public DbSet<Banca> Banca { get; set; }
     public DbSet<BancaAvaliador> BancaAvaliadores { get; set; }
     public DbSet<MembroExterno> MembrosExternos { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,5 +29,25 @@ public class AppDbContext : DbContext
             .WithMany()
             .HasForeignKey(ba => ba.ProfessorId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<RefreshToken>(entity =>
+        {
+            entity.ToTable("refresh_tokens");
+
+            entity.Property(rt => rt.TokenHash)
+                .HasColumnType("char(64)")
+                .IsRequired();
+
+            entity.Property(rt => rt.ReplacedByTokenHash)
+                .HasColumnType("char(64)");
+
+            entity.HasIndex(rt => rt.TokenHash).IsUnique();
+            entity.HasIndex(rt => rt.UsuarioId);
+
+            entity.HasOne(rt => rt.Usuario)
+                .WithMany()
+                .HasForeignKey(rt => rt.UsuarioId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
     }
 }

--- a/TccManager.Api/Logging/SensitiveDataMaskingPolicy.cs
+++ b/TccManager.Api/Logging/SensitiveDataMaskingPolicy.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TccManager.Api.Logging;
+
+/// <summary>
+/// Política de destructuring do Serilog que mascara propriedades sensíveis por nome
+/// (Senha, SenhaHash, Password, Token, Authorization), caso algum objeto com esses
+/// campos venha a ser logado por engano. Camada de defesa em profundidade — não
+/// substitui a disciplina de nunca passar esses valores ao logger na origem.
+/// </summary>
+public class SensitiveDataMaskingPolicy : IDestructuringPolicy
+{
+    private const string MaskedValue = "***REDACTED***";
+
+    private static readonly string[] SensitivePropertyNames =
+    {
+        "Senha",
+        "SenhaHash",
+        "Password",
+        "Token",
+        "Authorization"
+    };
+
+    public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+    {
+        result = null!;
+
+        if (value is null)
+            return false;
+
+        var type = value.GetType();
+
+        if (type.Namespace is not null &&
+            (type.Namespace.StartsWith("System", StringComparison.Ordinal) ||
+             type.Namespace.StartsWith("Microsoft", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        var hasSensitiveProperty = properties.Any(p =>
+            SensitivePropertyNames.Contains(p.Name, StringComparer.OrdinalIgnoreCase));
+
+        if (!hasSensitiveProperty)
+            return false;
+
+        var logEventProperties = new List<LogEventProperty>();
+
+        foreach (var property in properties)
+        {
+            if (property.GetIndexParameters().Length > 0)
+                continue;
+
+            var isSensitive = SensitivePropertyNames.Contains(property.Name, StringComparer.OrdinalIgnoreCase);
+
+            LogEventPropertyValue propertyValue;
+
+            if (isSensitive)
+            {
+                propertyValue = new ScalarValue(MaskedValue);
+            }
+            else
+            {
+                object? rawValue;
+                try
+                {
+                    rawValue = property.GetValue(value);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                propertyValue = propertyValueFactory.CreatePropertyValue(rawValue, destructureObjects: true);
+            }
+
+            logEventProperties.Add(new LogEventProperty(property.Name, propertyValue));
+        }
+
+        result = new StructureValue(logEventProperties, type.Name);
+        return true;
+    }
+}

--- a/TccManager.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/TccManager.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,28 @@
+using Serilog.Context;
+
+namespace TccManager.Api.Middleware;
+
+public class CorrelationIdMiddleware
+{
+    private const string HeaderName = "X-Correlation-Id";
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = context.Request.Headers.TryGetValue(HeaderName, out var existing) && Guid.TryParse(existing, out var parsed)
+            ? parsed.ToString()
+            : Guid.NewGuid().ToString();
+
+        context.Response.Headers[HeaderName] = correlationId;
+
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        {
+            await _next(context);
+        }
+    }
+}

--- a/TccManager.Api/Migrations/20260711181412_AddRefreshTokens.Designer.cs
+++ b/TccManager.Api/Migrations/20260711181412_AddRefreshTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TccManager.Api.Data;
 
@@ -11,9 +12,11 @@ using TccManager.Api.Data;
 namespace TccManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711181412_AddRefreshTokens")]
+    partial class AddRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TccManager.Api/Migrations/20260711181412_AddRefreshTokens.cs
+++ b/TccManager.Api/Migrations/20260711181412_AddRefreshTokens.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TccManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "refresh_tokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UsuarioId = table.Column<int>(type: "int", nullable: false),
+                    TokenHash = table.Column<string>(type: "char(64)", maxLength: 64, nullable: false),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RevokedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ReplacedByTokenHash = table.Column<string>(type: "char(64)", maxLength: 64, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_refresh_tokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_refresh_tokens_usuarios_UsuarioId",
+                        column: x => x.UsuarioId,
+                        principalTable: "usuarios",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_refresh_tokens_TokenHash",
+                table: "refresh_tokens",
+                column: "TokenHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_refresh_tokens_UsuarioId",
+                table: "refresh_tokens",
+                column: "UsuarioId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "refresh_tokens");
+        }
+    }
+}

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -3,83 +3,108 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Binders;
+using TccManager.Api.Configuration;
 using TccManager.Api.Data;
-using TccManager.Api.Data;
+using TccManager.Api.Middleware;
 using System.Text;
+using Serilog;
 
-var builder = WebApplication.CreateBuilder(args);
+LoggingSetup.CreateBootstrapLogger();
 
-builder.Services.AddControllers(options =>
+try
 {
-    options.ModelBinderProviders.Insert(0, new InvariantDecimalModelBinderProvider());
-})
-    .AddJsonOptions(options =>
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.ConfigureLogging();
+
+    builder.Services.AddControllers(options =>
     {
-        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
-    });
-
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-// Configuração do Entity Framework (Banco de Dados)
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
-
-var jwtKey = Encoding.ASCII.GetBytes(builder.Configuration["Jwt:Key"]!);
-
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-})
-.AddJwtBearer(options =>
-{
-    options.SaveToken = true;
-    options.TokenValidationParameters = new TokenValidationParameters
-    {
-        ValidateIssuerSigningKey = true,
-        IssuerSigningKey = new SymmetricSecurityKey(jwtKey),
-        ValidateIssuer = false,
-        ValidIssuer = builder.Configuration["Jwt:Issuer"],
-        ValidateAudience = false,
-        ValidAudience = builder.Configuration["Jwt:Audience"]
-    };
-});
-
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("AllowBlazorClient",
-        policy =>
+        options.ModelBinderProviders.Insert(0, new InvariantDecimalModelBinderProvider());
+    })
+        .AddJsonOptions(options =>
         {
-            policy.WithOrigins("https://localhost:7249", "http://localhost:5075")
-                  .AllowAnyHeader()
-                  .AllowAnyMethod();
+            options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
         });
-});
 
-var app = builder.Build();
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(options =>
+    // Configuração do Entity Framework (Banco de Dados)
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+    builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
+
+    var jwtKey = Encoding.ASCII.GetBytes(builder.Configuration["Jwt:Key"]!);
+
+    builder.Services.AddAuthentication(options =>
     {
-        options.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
-        options.RoutePrefix = string.Empty;
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
+    .AddJwtBearer(options =>
+    {
+        options.SaveToken = true;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(jwtKey),
+            ValidateIssuer = false,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidateAudience = false,
+            ValidAudience = builder.Configuration["Jwt:Audience"]
+        };
     });
+
+    builder.Services.AddCors(options =>
+    {
+        options.AddPolicy("AllowBlazorClient",
+            policy =>
+            {
+                policy.WithOrigins("https://localhost:7249", "http://localhost:5075")
+                      .AllowAnyHeader()
+                      .AllowAnyMethod();
+            });
+    });
+
+    builder.Services.ConfigureRateLimiting(builder.Configuration);
+
+    var app = builder.Build();
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI(options =>
+        {
+            options.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+            options.RoutePrefix = string.Empty;
+        });
+    }
+
+    app.UseMiddleware<CorrelationIdMiddleware>();
+
+    app.UseSerilogRequestLogging();
+
+    app.UseHttpsRedirection();
+
+    app.UseStaticFiles();
+
+    app.UseCors("AllowBlazorClient");
+
+    app.UseRateLimiter();
+
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.MapControllers();
+
+    app.Run();
 }
-
-app.UseHttpsRedirection();
-
-app.UseStaticFiles();
-
-app.UseCors("AllowBlazorClient");
-
-app.UseAuthentication();
-app.UseAuthorization();
-
-app.MapControllers();
-
-app.Run();
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Aplicação encerrada inesperadamente durante a inicialização");
+}
+finally
+{
+    Log.CloseAndFlush();
+}
 
 public partial class Program { }

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -7,6 +7,7 @@ using TccManager.Api.Configuration;
 using TccManager.Api.Data;
 using TccManager.Api.Middleware;
 using TccManager.Api.Services;
+using TccManager.Api.Services.Auth;
 using System.Text;
 using Serilog;
 
@@ -69,6 +70,9 @@ try
     builder.Services.ConfigureRateLimiting(builder.Configuration);
 
     builder.Services.AddSingleton<ISanitizerService, HtmlSanitizerService>();
+
+    builder.Services.AddScoped<ITokenService, TokenService>();
+    builder.Services.AddScoped<IAuthTokenService, AuthTokenService>();
 
     builder.Services.AddEmailNotifications(builder.Configuration);
 

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -70,6 +70,8 @@ try
 
     builder.Services.AddSingleton<ISanitizerService, HtmlSanitizerService>();
 
+    builder.Services.AddEmailNotifications(builder.Configuration);
+
     var app = builder.Build();
 
     if (app.Environment.IsDevelopment())

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -6,6 +6,7 @@ using TccManager.Api.Binders;
 using TccManager.Api.Configuration;
 using TccManager.Api.Data;
 using TccManager.Api.Middleware;
+using TccManager.Api.Services;
 using System.Text;
 using Serilog;
 
@@ -66,6 +67,8 @@ try
     });
 
     builder.Services.ConfigureRateLimiting(builder.Configuration);
+
+    builder.Services.AddSingleton<ISanitizerService, HtmlSanitizerService>();
 
     var app = builder.Build();
 

--- a/TccManager.Api/Resources/EmailTemplates/aceite-final.html
+++ b/TccManager.Api/Resources/EmailTemplates/aceite-final.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Aceite final concedido</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #2e7d32;">Aceite final concedido</h2>
+    <p>O orientador concedeu o aceite final da versão do TCC <strong>"{{TituloTcc}}"</strong>, do aluno <strong>{{NomeAluno}}</strong>.</p>
+    <p>O trabalho está liberado para agendamento da banca de defesa.</p>
+    <p>Acesse o SIGA-TCC para agendar a banca.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/banca-agendada.html
+++ b/TccManager.Api/Resources/EmailTemplates/banca-agendada.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Banca de TCC agendada</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #1565c0;">Banca de TCC agendada</h2>
+    <p>A banca de defesa do TCC <strong>"{{TituloTcc}}"</strong>, do aluno <strong>{{NomeAluno}}</strong>, foi agendada.</p>
+    <p><strong>Data e horário:</strong> {{DataHora}} (horário de Brasília)</p>
+    <p><strong>Local:</strong> {{Local}}</p>
+    <p><strong>Membros da banca avaliadora:</strong></p>
+    <ul>
+      {{ListaMembrosBanca}}
+    </ul>
+    <p>Caso você seja um membro externo convidado, esta mensagem serve como convite formal para participar da defesa.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/feedback-registrado.html
+++ b/TccManager.Api/Resources/EmailTemplates/feedback-registrado.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Feedback registrado</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #1565c0;">Novo feedback registrado</h2>
+    <p>Olá, <strong>{{NomeAluno}}</strong>,</p>
+    <p>Seu orientador registrou um feedback na entrega <strong>"{{TituloEntrega}}"</strong> do TCC <strong>"{{TituloTcc}}"</strong>.</p>
+    <p><strong>Nota:</strong> {{Nota}}</p>
+    <p><strong>Feedback:</strong></p>
+    <p style="background-color: #fafafa; border-left: 3px solid #1565c0; padding: 8px 12px;">{{Feedback}}</p>
+    <p>Acesse o SIGA-TCC para ver todos os detalhes.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/proposta-aprovada.html
+++ b/TccManager.Api/Resources/EmailTemplates/proposta-aprovada.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Proposta de TCC aprovada</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #2e7d32;">Proposta de TCC aprovada</h2>
+    <p>Olá, <strong>{{NomeAluno}}</strong>,</p>
+    <p>Sua proposta de TCC <strong>"{{TituloTcc}}"</strong> foi aprovada.</p>
+    <p>Seu orientador designado é: <strong>{{NomeOrientador}}</strong>.</p>
+    <p>Acesse o SIGA-TCC para acompanhar os próximos passos do seu trabalho.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/proposta-rejeitada.html
+++ b/TccManager.Api/Resources/EmailTemplates/proposta-rejeitada.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Proposta de TCC rejeitada</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #c62828;">Proposta de TCC rejeitada</h2>
+    <p>Olá, <strong>{{NomeAluno}}</strong>,</p>
+    <p>Sua proposta de TCC <strong>"{{TituloTcc}}"</strong> não foi aprovada pelo orientador.</p>
+    <p><strong>Motivo informado:</strong></p>
+    <p style="background-color: #fafafa; border-left: 3px solid #c62828; padding: 8px 12px;">{{MotivoRejeicao}}</p>
+    <p>Você pode ajustar sua proposta e enviá-la novamente através do SIGA-TCC.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/resultado-aprovado.html
+++ b/TccManager.Api/Resources/EmailTemplates/resultado-aprovado.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Resultado final da banca: aprovado</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #2e7d32;">Parabéns! TCC aprovado na banca</h2>
+    <p>O TCC <strong>"{{TituloTcc}}"</strong>, do aluno <strong>{{NomeAluno}}</strong>, foi <strong>aprovado</strong> pela banca examinadora.</p>
+    <p><strong>Nota final:</strong> {{NotaFinal}}</p>
+    <p>O trabalho foi finalizado com sucesso. Parabéns a todos os envolvidos!</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Resources/EmailTemplates/resultado-reprovado.html
+++ b/TccManager.Api/Resources/EmailTemplates/resultado-reprovado.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Resultado final da banca: reprovado</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #c62828;">Resultado da banca: reprovado</h2>
+    <p>O TCC <strong>"{{TituloTcc}}"</strong>, do aluno <strong>{{NomeAluno}}</strong>, foi <strong>reprovado</strong> pela banca examinadora.</p>
+    <p><strong>Nota final:</strong> {{NotaFinal}}</p>
+    <p><strong>Motivo informado:</strong></p>
+    <p style="background-color: #fafafa; border-left: 3px solid #c62828; padding: 8px 12px;">{{MotivoRejeicao}}</p>
+    <p>Acesse o SIGA-TCC para mais detalhes sobre os próximos passos.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Services/Auth/AuthTokenService.cs
+++ b/TccManager.Api/Services/Auth/AuthTokenService.cs
@@ -1,0 +1,137 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Api.Data;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Models;
+
+namespace TccManager.Api.Services.Auth;
+
+public class AuthTokenService : IAuthTokenService
+{
+    private readonly AppDbContext _context;
+    private readonly ITokenService _tokenService;
+    private readonly IConfiguration _configuration;
+
+    public AuthTokenService(AppDbContext context, ITokenService tokenService, IConfiguration configuration)
+    {
+        _context = context;
+        _tokenService = tokenService;
+        _configuration = configuration;
+    }
+
+    private int RefreshTokenDays => _configuration.GetValue<int?>("Jwt:RefreshTokenDays") ?? 7;
+
+    public async Task<TokenPairDto> LoginAsync(Usuario usuario)
+    {
+        await RevokeAllForUserAsync(usuario.Id);
+
+        var (par, _) = CriarNovoPar(usuario);
+        await _context.SaveChangesAsync();
+
+        return par;
+    }
+
+    public async Task<TokenPairDto?> RefreshAsync(string refreshTokenBruto)
+    {
+        var hash = CalcularHash(refreshTokenBruto);
+
+        var tokenAtual = await _context.RefreshTokens
+            .Include(rt => rt.Usuario)
+            .FirstOrDefaultAsync(rt => rt.TokenHash == hash);
+
+        if (tokenAtual == null || tokenAtual.Usuario == null || !EhUtilizavel(tokenAtual))
+            return null;
+
+        var (par, novoRefreshToken) = CriarNovoPar(tokenAtual.Usuario);
+
+        tokenAtual.RevokedAtUtc = DateTime.UtcNow;
+        tokenAtual.ReplacedByTokenHash = novoRefreshToken.TokenHash;
+
+        await _context.SaveChangesAsync();
+
+        return par;
+    }
+
+    public async Task LogoutAsync(string refreshTokenBruto)
+    {
+        var hash = CalcularHash(refreshTokenBruto);
+
+        var token = await _context.RefreshTokens
+            .FirstOrDefaultAsync(rt => rt.TokenHash == hash);
+
+        if (token == null || token.RevokedAtUtc != null)
+            return;
+
+        token.RevokedAtUtc = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Revogação em massa (RF04), usada internamente pelo login. O documento de dados
+    /// recomenda <c>ExecuteUpdateAsync</c> (set-based, sem materializar entidades); na
+    /// prática, o provider EF Core InMemory usado pela suíte de testes de integração
+    /// deste projeto (<c>TccApiFactory</c>) não suporta <c>ExecuteUpdateAsync</c>/
+    /// <c>ExecuteDeleteAsync</c> (lança <see cref="InvalidOperationException"/>), o que
+    /// quebraria o login em todo teste de integração existente. Optei por carregar as
+    /// entidades ativas e atualizá-las via change tracker — ainda 100% EF Core, apenas
+    /// sem o SQL set-based — coerente com o próprio documento de dados, que já registra
+    /// que o volume de linhas por usuário é baixíssimo neste projeto. Fica registrado
+    /// como decisão de implementação para revisão, caso o volume real cresça.
+    /// </summary>
+    private async Task RevokeAllForUserAsync(int usuarioId)
+    {
+        var agora = DateTime.UtcNow;
+
+        var tokensAtivos = await _context.RefreshTokens
+            .Where(rt => rt.UsuarioId == usuarioId && rt.RevokedAtUtc == null)
+            .ToListAsync();
+
+        foreach (var token in tokensAtivos)
+        {
+            token.RevokedAtUtc = agora;
+        }
+    }
+
+    private (TokenPairDto Par, RefreshToken NovoRefreshToken) CriarNovoPar(Usuario usuario)
+    {
+        var (accessToken, expiresAtUtc) = _tokenService.GerarAccessToken(usuario);
+
+        // CSPRNG (não Guid.NewGuid): o refresh token é uma credencial de portador de 7 dias,
+        // precisa de garantia de imprevisibilidade criptográfica, não apenas unicidade.
+        var refreshTokenBruto = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+        var agora = DateTime.UtcNow;
+
+        var novoRefreshToken = new RefreshToken
+        {
+            UsuarioId = usuario.Id,
+            TokenHash = CalcularHash(refreshTokenBruto),
+            CreatedAtUtc = agora,
+            ExpiresAtUtc = agora.AddDays(RefreshTokenDays)
+        };
+
+        _context.RefreshTokens.Add(novoRefreshToken);
+
+        var par = new TokenPairDto
+        {
+            Token = accessToken,
+            RefreshToken = refreshTokenBruto,
+            ExpiresAtUtc = expiresAtUtc
+        };
+
+        return (par, novoRefreshToken);
+    }
+
+    private static bool EhUtilizavel(RefreshToken token) =>
+        token.RevokedAtUtc == null && token.ExpiresAtUtc > DateTime.UtcNow;
+
+    /// <summary>
+    /// SHA-256 em hex, sempre minúsculo — garante comparação confiável de igualdade em
+    /// <c>TokenHash</c> independentemente da collation do banco (ver docs/dados).
+    /// </summary>
+    private static string CalcularHash(string valor)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(valor));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+}

--- a/TccManager.Api/Services/Auth/IAuthTokenService.cs
+++ b/TccManager.Api/Services/Auth/IAuthTokenService.cs
@@ -1,0 +1,31 @@
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Models;
+
+namespace TccManager.Api.Services.Auth;
+
+/// <summary>
+/// Fachada de sessão consumida pelo <c>AuthController</c>: login (emissão + revogação de
+/// sessões antigas), refresh (validação + rotação) e logout (revogação). Persistência via
+/// EF Core, conforme decidido em docs/dados/2026-07-10-refresh-token-sessao.md.
+/// </summary>
+public interface IAuthTokenService
+{
+    /// <summary>
+    /// Revoga todos os refresh tokens ativos do usuário (sessão única — RF04) e emite um
+    /// novo par (JWT + refresh token).
+    /// </summary>
+    Task<TokenPairDto> LoginAsync(Usuario usuario);
+
+    /// <summary>
+    /// Valida o refresh token informado (existe, não revogado, não expirado). Em caso
+    /// válido, rotaciona (revoga o apresentado, emite um novo) e retorna o novo par.
+    /// Retorna <c>null</c> se o refresh token for inválido/expirado/revogado.
+    /// </summary>
+    Task<TokenPairDto?> RefreshAsync(string refreshTokenBruto);
+
+    /// <summary>
+    /// Revoga o refresh token informado (RF05). Idempotente: token inexistente ou já
+    /// revogado não gera erro.
+    /// </summary>
+    Task LogoutAsync(string refreshTokenBruto);
+}

--- a/TccManager.Api/Services/Auth/ITokenService.cs
+++ b/TccManager.Api/Services/Auth/ITokenService.cs
@@ -1,0 +1,12 @@
+using TccManager.Shared.Models;
+
+namespace TccManager.Api.Services.Auth;
+
+/// <summary>
+/// Responsável exclusivamente pela emissão/assinatura do JWT de acesso.
+/// Lê a expiração de <c>Jwt:AccessTokenMinutes</c> (default 15).
+/// </summary>
+public interface ITokenService
+{
+    (string Token, DateTime ExpiresAtUtc) GerarAccessToken(Usuario usuario);
+}

--- a/TccManager.Api/Services/Auth/TokenService.cs
+++ b/TccManager.Api/Services/Auth/TokenService.cs
@@ -1,0 +1,46 @@
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using TccManager.Shared.Models;
+
+namespace TccManager.Api.Services.Auth;
+
+public class TokenService : ITokenService
+{
+    private readonly IConfiguration _configuration;
+
+    public TokenService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    private int AccessTokenMinutes => _configuration.GetValue<int?>("Jwt:AccessTokenMinutes") ?? 15;
+
+    public (string Token, DateTime ExpiresAtUtc) GerarAccessToken(Usuario usuario)
+    {
+        var key = Encoding.ASCII.GetBytes(_configuration["Jwt:Key"]!);
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString()),
+            new Claim(ClaimTypes.Name, usuario.Nome),
+            new Claim(ClaimTypes.Email, usuario.Email),
+            new Claim(ClaimTypes.Role, usuario.Tipo.ToString())
+        };
+
+        var expiresAtUtc = DateTime.UtcNow.AddMinutes(AccessTokenMinutes);
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Expires = expiresAtUtc,
+            Issuer = _configuration["Jwt:Issuer"],
+            Audience = _configuration["Jwt:Audience"],
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return (tokenHandler.WriteToken(token), expiresAtUtc);
+    }
+}

--- a/TccManager.Api/Services/Email/ChannelEmailQueue.cs
+++ b/TccManager.Api/Services/Email/ChannelEmailQueue.cs
@@ -1,0 +1,45 @@
+using System.Threading.Channels;
+
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Implementação de <see cref="IEmailQueue"/> via System.Threading.Channels. Canal
+/// bounded (capacidade ~1000) com FullMode = DropWrite: se encher, o produtor descarta
+/// a mensagem mais nova e loga um warning, em vez de bloquear a requisição HTTP —
+/// consistente com a política de "falha silenciosa" e improvável no volume local do projeto.
+/// </summary>
+public class ChannelEmailQueue : IEmailQueue
+{
+    private const int Capacidade = 1000;
+
+    private readonly Channel<EmailMessage> _channel;
+    private readonly ILogger<ChannelEmailQueue> _logger;
+
+    public ChannelEmailQueue(ILogger<ChannelEmailQueue> logger)
+    {
+        _logger = logger;
+        _channel = Channel.CreateBounded<EmailMessage>(new BoundedChannelOptions(Capacidade)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    public bool Enqueue(EmailMessage mensagem)
+    {
+        var sucesso = _channel.Writer.TryWrite(mensagem);
+
+        if (!sucesso)
+        {
+            _logger.LogWarning(
+                "Fila de e-mails cheia (capacidade {Capacidade}); mensagem descartada. Assunto: {Assunto}, Destinatarios: {QtdDestinatarios}",
+                Capacidade, mensagem.Assunto, mensagem.Destinatarios.Count);
+        }
+
+        return sucesso;
+    }
+
+    public IAsyncEnumerable<EmailMessage> DequeueAllAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/TccManager.Api/Services/Email/EmailBackgroundService.cs
+++ b/TccManager.Api/Services/Email/EmailBackgroundService.cs
@@ -1,0 +1,47 @@
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Hosted service que consome o Channel de e-mails fora do ciclo da requisição HTTP.
+/// Ponto único de try/catch + log Serilog para falha de envio (RF4/RNF1): uma falha de
+/// SMTP nunca derruba o worker nem propaga para o request que originou a notificação.
+/// Sem DbContext aqui — os dados de destinatário já foram resolvidos antes de a mensagem
+/// entrar na fila, evitando ObjectDisposedException de um DbContext scoped já descartado.
+/// </summary>
+public class EmailBackgroundService : BackgroundService
+{
+    private readonly IEmailQueue _queue;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<EmailBackgroundService> _logger;
+
+    public EmailBackgroundService(IEmailQueue queue, IEmailService emailService, ILogger<EmailBackgroundService> logger)
+    {
+        _queue = queue;
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await foreach (var mensagem in _queue.DequeueAllAsync(stoppingToken))
+            {
+                try
+                {
+                    await _emailService.EnviarAsync(mensagem, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Falha ao enviar e-mail. Assunto: {Assunto}, Destinatarios: {QtdDestinatarios}",
+                        mensagem.Assunto, mensagem.Destinatarios.Count);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Encerramento normal do host (shutdown) — não é falha de envio.
+        }
+    }
+}

--- a/TccManager.Api/Services/Email/EmailMessage.cs
+++ b/TccManager.Api/Services/Email/EmailMessage.cs
@@ -1,0 +1,21 @@
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Mensagem de e-mail já pronta para envio: destinatários resolvidos e corpo já
+/// renderizado. É o único objeto que cruza do request (onde é montado, com acesso
+/// ao AppDbContext scoped) para o Channel consumido pelo EmailBackgroundService.
+/// O remetente não faz parte deste objeto — vem de EmailSettings no momento do envio.
+/// </summary>
+public sealed class EmailMessage
+{
+    public IReadOnlyList<string> Destinatarios { get; }
+    public string Assunto { get; }
+    public string CorpoHtml { get; }
+
+    public EmailMessage(IReadOnlyList<string> destinatarios, string assunto, string corpoHtml)
+    {
+        Destinatarios = destinatarios;
+        Assunto = assunto;
+        CorpoHtml = corpoHtml;
+    }
+}

--- a/TccManager.Api/Services/Email/EmailSettings.cs
+++ b/TccManager.Api/Services/Email/EmailSettings.cs
@@ -1,0 +1,25 @@
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Options bindadas da seção "Email" da configuração. Em desenvolvimento, os valores
+/// reais (host, porta, usuário, senha, remetente) vêm de User Secrets — o esqueleto
+/// versionado em appsettings.json fica vazio, mesmo padrão já usado para Jwt:Key.
+/// </summary>
+public class EmailSettings
+{
+    public SmtpSettings Smtp { get; set; } = new();
+
+    /// <summary>
+    /// Remetente completo (nome + endereço), ex.: "SIGA-TCC &lt;noreply@siga-tcc.local&gt;".
+    /// </summary>
+    public string From { get; set; } = string.Empty;
+}
+
+public class SmtpSettings
+{
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; } = 25;
+    public string? User { get; set; }
+    public string? Password { get; set; }
+    public bool UseSsl { get; set; }
+}

--- a/TccManager.Api/Services/Email/IEmailQueue.cs
+++ b/TccManager.Api/Services/Email/IEmailQueue.cs
@@ -1,0 +1,18 @@
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Fila em memória (produtor/consumidor) usada para desacoplar a latência do SMTP do
+/// ciclo da requisição HTTP (RF3/RNF2). Não é uma fila durável: mensagens pendentes são
+/// perdidas se o processo cair — decisão de produto aceita explicitamente (sem retry,
+/// sem mensageria persistente neste MVP).
+/// </summary>
+public interface IEmailQueue
+{
+    /// <summary>
+    /// Enfileira a mensagem para envio posterior. Retorna false se a fila estiver cheia
+    /// (mensagem descartada) — quem chama deve logar esse caso.
+    /// </summary>
+    bool Enqueue(EmailMessage mensagem);
+
+    IAsyncEnumerable<EmailMessage> DequeueAllAsync(CancellationToken cancellationToken);
+}

--- a/TccManager.Api/Services/Email/IEmailService.cs
+++ b/TccManager.Api/Services/Email/IEmailService.cs
@@ -1,0 +1,11 @@
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Abstração de envio de e-mail (RF1). Permite trocar a implementação (hoje MailKit/SMTP)
+/// sem alterar consumidores. Não é responsabilidade desta interface tratar falhas de
+/// forma silenciosa — quem chama (EmailBackgroundService) é o ponto central de try/catch.
+/// </summary>
+public interface IEmailService
+{
+    Task EnviarAsync(EmailMessage mensagem, CancellationToken cancellationToken = default);
+}

--- a/TccManager.Api/Services/Email/MailKitEmailService.cs
+++ b/TccManager.Api/Services/Email/MailKitEmailService.cs
@@ -1,0 +1,57 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace TccManager.Api.Services.Email;
+
+/// <summary>
+/// Implementação de <see cref="IEmailService"/> via MailKit/SMTP (RF2), apontando em
+/// desenvolvimento para um servidor sandbox local (ex.: smtp4dev, Papercut). Não faz
+/// try/catch de envio: exceções propagam para o chamador (EmailBackgroundService), que
+/// é o ponto central de log de falha (RF4/RNF1). Registrado como Singleton: um SmtpClient
+/// novo é criado a cada chamada, pois o cliente MailKit não é thread-safe para reuso
+/// concorrente entre múltiplos envios simultâneos.
+/// </summary>
+public class MailKitEmailService : IEmailService
+{
+    private readonly EmailSettings _settings;
+
+    public MailKitEmailService(IOptions<EmailSettings> settings)
+    {
+        _settings = settings.Value;
+    }
+
+    public async Task EnviarAsync(EmailMessage mensagem, CancellationToken cancellationToken = default)
+    {
+        var mimeMessage = new MimeMessage();
+        mimeMessage.From.Add(MailboxAddress.Parse(_settings.From));
+
+        foreach (var destinatario in mensagem.Destinatarios)
+        {
+            mimeMessage.To.Add(MailboxAddress.Parse(destinatario));
+        }
+
+        mimeMessage.Subject = mensagem.Assunto;
+        mimeMessage.Body = new TextPart(MimeKit.Text.TextFormat.Html)
+        {
+            Text = mensagem.CorpoHtml
+        };
+
+        using var client = new SmtpClient();
+
+        var opcoesSocket = _settings.Smtp.UseSsl
+            ? SecureSocketOptions.SslOnConnect
+            : SecureSocketOptions.StartTlsWhenAvailable;
+
+        await client.ConnectAsync(_settings.Smtp.Host, _settings.Smtp.Port, opcoesSocket, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(_settings.Smtp.User))
+        {
+            await client.AuthenticateAsync(_settings.Smtp.User, _settings.Smtp.Password ?? string.Empty, cancellationToken);
+        }
+
+        await client.SendAsync(mimeMessage, cancellationToken);
+        await client.DisconnectAsync(true, cancellationToken);
+    }
+}

--- a/TccManager.Api/Services/HtmlSanitizerService.cs
+++ b/TccManager.Api/Services/HtmlSanitizerService.cs
@@ -1,0 +1,41 @@
+using Ganss.Xss;
+
+namespace TccManager.Api.Services;
+
+/// <summary>
+/// Implementação de <see cref="ISanitizerService"/> baseada no pacote Ganss.Xss (HtmlSanitizer).
+/// Política: remove todas as tags HTML da entrada, preservando o texto interno como texto puro.
+/// Registrada como Singleton no DI: o método Sanitize do HtmlSanitizer é thread-safe desde que a
+/// configuração (allowlists) não seja alterada após a construção da instância, o que é o caso aqui
+/// (configuração feita uma única vez no construtor e nunca mais alterada).
+/// </summary>
+public class HtmlSanitizerService : ISanitizerService
+{
+    private readonly HtmlSanitizer _sanitizer;
+
+    public HtmlSanitizerService()
+    {
+        _sanitizer = new HtmlSanitizer();
+
+        // Preserva o texto interno das tags removidas (produz texto puro em vez de descartar o conteúdo).
+        _sanitizer.KeepChildNodes = true;
+
+        // Nenhuma tag, atributo, propriedade CSS, at-rule ou esquema de URI é permitido: remove todo HTML.
+        _sanitizer.AllowedTags.Clear();
+        _sanitizer.AllowedAttributes.Clear();
+        _sanitizer.AllowedCssProperties.Clear();
+        _sanitizer.AllowedAtRules.Clear();
+        _sanitizer.AllowedSchemes.Clear();
+    }
+
+    public string? Sanitizar(string? entrada)
+    {
+        if (string.IsNullOrEmpty(entrada))
+            return entrada;
+
+        // Não decodificar o resultado: entidades HTML remanescentes (ex. "&lt;") representam
+        // caracteres literais digitados pelo usuário e sua forma codificada é o que garante que
+        // futuros consumidores (e-mail HTML, PDF) não reintroduzam HTML/JS executável.
+        return _sanitizer.Sanitize(entrada);
+    }
+}

--- a/TccManager.Api/Services/ISanitizerService.cs
+++ b/TccManager.Api/Services/ISanitizerService.cs
@@ -1,0 +1,6 @@
+namespace TccManager.Api.Services;
+
+public interface ISanitizerService
+{
+    string? Sanitizar(string? entrada);
+}

--- a/TccManager.Api/Services/Notifications/FileEmailTemplateRenderer.cs
+++ b/TccManager.Api/Services/Notifications/FileEmailTemplateRenderer.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+
+namespace TccManager.Api.Services.Notifications;
+
+/// <summary>
+/// Carrega os 7 templates .html de Resources/EmailTemplates (embutidos como embedded
+/// resource no .csproj) e substitui placeholders "{{Chave}}". Cache em memória por chave
+/// evita reler o assembly a cada envio (I/O ocorre só uma vez por template, na primeira vez).
+/// </summary>
+public class FileEmailTemplateRenderer : IEmailTemplateRenderer
+{
+    private static readonly ConcurrentDictionary<string, string> Cache = new();
+
+    public string Render(string chaveTemplate, IReadOnlyDictionary<string, string> valores)
+    {
+        var template = Cache.GetOrAdd(chaveTemplate, CarregarTemplate);
+
+        var corpo = template;
+        foreach (var (chave, valor) in valores)
+        {
+            corpo = corpo.Replace($"{{{{{chave}}}}}", valor ?? string.Empty);
+        }
+
+        return corpo;
+    }
+
+    private static string CarregarTemplate(string chaveTemplate)
+    {
+        var assembly = typeof(FileEmailTemplateRenderer).Assembly;
+        var resourceName = $"TccManager.Api.Resources.EmailTemplates.{chaveTemplate}.html";
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Template de e-mail não encontrado: {resourceName}");
+
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}

--- a/TccManager.Api/Services/Notifications/IEmailTemplateRenderer.cs
+++ b/TccManager.Api/Services/Notifications/IEmailTemplateRenderer.cs
@@ -1,0 +1,18 @@
+namespace TccManager.Api.Services.Notifications;
+
+/// <summary>
+/// Isola a estratégia de renderização de template (hoje: arquivo .html embutido como
+/// embedded resource + substituição de placeholders {{Chave}}), permitindo trocar por
+/// Razor no futuro sem afetar TccNotificationService.
+/// </summary>
+public interface IEmailTemplateRenderer
+{
+    /// <summary>
+    /// Renderiza o template identificado por <paramref name="chaveTemplate"/> (nome do
+    /// arquivo .html, sem extensão, ex.: "proposta-aprovada"), substituindo cada
+    /// ocorrência de "{{Chave}}" pelo valor correspondente em <paramref name="valores"/>.
+    /// Os valores já devem vir prontos para inserção no HTML (texto plano ou fragmento
+    /// HTML controlado) — o renderer não faz encoding adicional.
+    /// </summary>
+    string Render(string chaveTemplate, IReadOnlyDictionary<string, string> valores);
+}

--- a/TccManager.Api/Services/Notifications/ITccNotificationService.cs
+++ b/TccManager.Api/Services/Notifications/ITccNotificationService.cs
@@ -1,0 +1,33 @@
+namespace TccManager.Api.Services.Notifications;
+
+/// <summary>
+/// Fachada semântica consumida pelos controllers: um método por evento de negócio,
+/// sem expor destinatários/templates/fila. Contrato: nunca lança exceção — qualquer
+/// falha (consulta de destinatário, renderização, fila cheia) vira log Serilog e o
+/// método retorna normalmente, garantindo que o fluxo de negócio do controller nunca
+/// seja afetado pelo envio de e-mail (RF3/RF4/RNF1).
+/// </summary>
+public interface ITccNotificationService
+{
+    /// <summary>Proposta aprovada (RF7) — Aluno. Disparado tanto por AprovarProposta quanto por DesignarOrientador.</summary>
+    Task NotificarPropostaAprovadaAsync(int tccId);
+
+    /// <summary>Proposta rejeitada (RF8) — Aluno, com motivo.</summary>
+    Task NotificarPropostaRejeitadaAsync(int tccId);
+
+    /// <summary>Banca agendada (RF9) — Aluno, Orientador e avaliadores (internos e externos).</summary>
+    Task NotificarBancaAgendadaAsync(int bancaId);
+
+    /// <summary>Feedback de entrega registrado (RF10) — Aluno.</summary>
+    Task NotificarFeedbackRegistradoAsync(int entregaId);
+
+    /// <summary>Aceite final concedido (RF11) — Aluno e todos os usuários Tipo = Coordenador.</summary>
+    Task NotificarAceiteFinalAsync(int tccId);
+
+    /// <summary>
+    /// Resultado final da banca (RF12/RF13) — Aluno e Orientador sempre; se reprovado,
+    /// também todos os usuários Tipo = Coordenador. <paramref name="aprovado"/> escolhe
+    /// o template (resultado-aprovado vs. resultado-reprovado).
+    /// </summary>
+    Task NotificarResultadoBancaAsync(int bancaId, bool aprovado);
+}

--- a/TccManager.Api/Services/Notifications/TccNotificationService.cs
+++ b/TccManager.Api/Services/Notifications/TccNotificationService.cs
@@ -1,0 +1,348 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Api.Data;
+using TccManager.Api.Services;
+using TccManager.Api.Services.Email;
+using TccManager.Shared.Enums;
+
+namespace TccManager.Api.Services.Notifications;
+
+/// <summary>
+/// Orquestração de notificações de negócio: resolve destinatários via AppDbContext
+/// (scoped, dentro do request), renderiza o template e enfileira o EmailMessage pronto
+/// (IEmailQueue). Não conhece MailKit/SMTP. Nunca lança exceção para o chamador — cada
+/// método público envolve seu corpo em try/catch + log (contrato de não-lançamento da
+/// arquitetura).
+/// </summary>
+public class TccNotificationService : ITccNotificationService
+{
+    private readonly AppDbContext _context;
+    private readonly IEmailTemplateRenderer _renderer;
+    private readonly IEmailQueue _queue;
+    private readonly ILogger<TccNotificationService> _logger;
+
+    public TccNotificationService(
+        AppDbContext context,
+        IEmailTemplateRenderer renderer,
+        IEmailQueue queue,
+        ILogger<TccNotificationService> logger)
+    {
+        _context = context;
+        _renderer = renderer;
+        _queue = queue;
+        _logger = logger;
+    }
+
+    public async Task NotificarPropostaAprovadaAsync(int tccId)
+    {
+        try
+        {
+            var tcc = await _context.Tccs
+                .Include(t => t.Aluno)
+                .Include(t => t.Orientador)
+                .FirstOrDefaultAsync(t => t.Id == tccId);
+
+            if (tcc == null)
+            {
+                _logger.LogWarning("NotificarPropostaAprovadaAsync: Tcc {TccId} não encontrado.", tccId);
+                return;
+            }
+
+            var destinatarios = ColetarEmails(("Aluno", tcc.Aluno?.Email));
+            if (destinatarios.Count == 0) return;
+
+            var corpo = _renderer.Render("proposta-aprovada", new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(tcc.Titulo),
+                ["NomeOrientador"] = Codificar(tcc.Orientador?.Nome)
+            });
+
+            Enfileirar(destinatarios, "Proposta de TCC aprovada", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de proposta aprovada para o Tcc {TccId}.", tccId);
+        }
+    }
+
+    public async Task NotificarPropostaRejeitadaAsync(int tccId)
+    {
+        try
+        {
+            var tcc = await _context.Tccs
+                .Include(t => t.Aluno)
+                .FirstOrDefaultAsync(t => t.Id == tccId);
+
+            if (tcc == null)
+            {
+                _logger.LogWarning("NotificarPropostaRejeitadaAsync: Tcc {TccId} não encontrado.", tccId);
+                return;
+            }
+
+            var destinatarios = ColetarEmails(("Aluno", tcc.Aluno?.Email));
+            if (destinatarios.Count == 0) return;
+
+            var corpo = _renderer.Render("proposta-rejeitada", new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(tcc.Titulo),
+                ["MotivoRejeicao"] = Codificar(tcc.MotivoRejeicao) is { Length: > 0 } motivo ? motivo : "Não informado"
+            });
+
+            Enfileirar(destinatarios, "Proposta de TCC rejeitada", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de proposta rejeitada para o Tcc {TccId}.", tccId);
+        }
+    }
+
+    public async Task NotificarBancaAgendadaAsync(int bancaId)
+    {
+        try
+        {
+            var banca = await _context.Banca
+                .Include(b => b.Tcc!).ThenInclude(t => t.Aluno)
+                .Include(b => b.Tcc!).ThenInclude(t => t.Orientador)
+                .Include(b => b.Avaliadores).ThenInclude(a => a.Professor)
+                .Include(b => b.Avaliadores).ThenInclude(a => a.MembroExterno)
+                .FirstOrDefaultAsync(b => b.Id == bancaId);
+
+            if (banca?.Tcc == null)
+            {
+                _logger.LogWarning("NotificarBancaAgendadaAsync: Banca {BancaId} ou Tcc associado não encontrado.", bancaId);
+                return;
+            }
+
+            var candidatos = new List<(string Papel, string? Email)>
+            {
+                ("Aluno", banca.Tcc.Aluno?.Email),
+                ("Orientador", banca.Tcc.Orientador?.Email)
+            };
+
+            var nomesAvaliadores = new List<string>();
+
+            foreach (var avaliador in banca.Avaliadores)
+            {
+                if (avaliador.ProfessorId.HasValue && avaliador.Professor != null)
+                {
+                    candidatos.Add(($"Avaliador interno {avaliador.Professor.Nome}", avaliador.Professor.Email));
+                    nomesAvaliadores.Add(avaliador.Professor.Nome);
+                }
+                else if (avaliador.MembroExternoId.HasValue && avaliador.MembroExterno != null)
+                {
+                    candidatos.Add(($"Avaliador externo {avaliador.MembroExterno.Nome}", avaliador.MembroExterno.Email));
+                    nomesAvaliadores.Add($"{avaliador.MembroExterno.Nome} ({avaliador.MembroExterno.Instituicao})");
+                }
+                else
+                {
+                    // Defesa em profundidade: BancaAvaliador sem ProfessorId nem MembroExternoId
+                    // resolvido não deve derrubar a notificação dos demais destinatários (ver
+                    // docs/dados — não há constraint XOR no banco garantindo exatamente um preenchido).
+                    _logger.LogWarning(
+                        "BancaAvaliador {Id} sem Professor nem MembroExterno resolvido; ignorado na notificação da Banca {BancaId}.",
+                        avaliador.Id, bancaId);
+                }
+            }
+
+            var destinatarios = ColetarEmails(candidatos.ToArray());
+            if (destinatarios.Count == 0) return;
+
+            var dataHoraBrasilia = BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(banca.DataHora);
+            var listaMembrosHtml = nomesAvaliadores.Count > 0
+                ? string.Concat(nomesAvaliadores.Select(n => $"<li>{WebUtility.HtmlEncode(n)}</li>"))
+                : "<li>Nenhum avaliador registrado</li>";
+
+            var corpo = _renderer.Render("banca-agendada", new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(banca.Tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(banca.Tcc.Titulo),
+                ["DataHora"] = dataHoraBrasilia.ToString("dd/MM/yyyy HH:mm"),
+                ["Local"] = Codificar(banca.Local),
+                ["ListaMembrosBanca"] = listaMembrosHtml
+            });
+
+            Enfileirar(destinatarios, "Banca de TCC agendada", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de banca agendada para a Banca {BancaId}.", bancaId);
+        }
+    }
+
+    public async Task NotificarFeedbackRegistradoAsync(int entregaId)
+    {
+        try
+        {
+            var entrega = await _context.Entregas
+                .Include(e => e.Tcc!).ThenInclude(t => t.Aluno)
+                .FirstOrDefaultAsync(e => e.Id == entregaId);
+
+            if (entrega?.Tcc == null)
+            {
+                _logger.LogWarning("NotificarFeedbackRegistradoAsync: Entrega {EntregaId} ou Tcc associado não encontrado.", entregaId);
+                return;
+            }
+
+            var destinatarios = ColetarEmails(("Aluno", entrega.Tcc.Aluno?.Email));
+            if (destinatarios.Count == 0) return;
+
+            var corpo = _renderer.Render("feedback-registrado", new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(entrega.Tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(entrega.Tcc.Titulo),
+                ["TituloEntrega"] = Codificar(entrega.Titulo),
+                ["Feedback"] = Codificar(entrega.Feedback) is { Length: > 0 } feedback ? feedback : "Sem comentários adicionais.",
+                ["Nota"] = entrega.Nota.HasValue ? entrega.Nota.Value.ToString("0.0") : "Não informada"
+            });
+
+            Enfileirar(destinatarios, "Feedback registrado na sua entrega", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de feedback registrado para a Entrega {EntregaId}.", entregaId);
+        }
+    }
+
+    public async Task NotificarAceiteFinalAsync(int tccId)
+    {
+        try
+        {
+            var tcc = await _context.Tccs
+                .Include(t => t.Aluno)
+                .FirstOrDefaultAsync(t => t.Id == tccId);
+
+            if (tcc == null)
+            {
+                _logger.LogWarning("NotificarAceiteFinalAsync: Tcc {TccId} não encontrado.", tccId);
+                return;
+            }
+
+            var candidatos = new List<(string Papel, string? Email)> { ("Aluno", tcc.Aluno?.Email) };
+            candidatos.AddRange(await ObterCandidatosCoordenadoresAsync());
+
+            var destinatarios = ColetarEmails(candidatos.ToArray());
+            if (destinatarios.Count == 0) return;
+
+            var corpo = _renderer.Render("aceite-final", new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(tcc.Titulo)
+            });
+
+            Enfileirar(destinatarios, "Aceite final concedido", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de aceite final para o Tcc {TccId}.", tccId);
+        }
+    }
+
+    public async Task NotificarResultadoBancaAsync(int bancaId, bool aprovado)
+    {
+        try
+        {
+            var banca = await _context.Banca
+                .Include(b => b.Tcc!).ThenInclude(t => t.Aluno)
+                .Include(b => b.Tcc!).ThenInclude(t => t.Orientador)
+                .FirstOrDefaultAsync(b => b.Id == bancaId);
+
+            if (banca?.Tcc == null)
+            {
+                _logger.LogWarning("NotificarResultadoBancaAsync: Banca {BancaId} ou Tcc associado não encontrado.", bancaId);
+                return;
+            }
+
+            var candidatos = new List<(string Papel, string? Email)>
+            {
+                ("Aluno", banca.Tcc.Aluno?.Email),
+                ("Orientador", banca.Tcc.Orientador?.Email)
+            };
+
+            var chaveTemplate = "resultado-aprovado";
+            var assunto = "Resultado final da banca: aprovado";
+
+            var valores = new Dictionary<string, string>
+            {
+                ["NomeAluno"] = Codificar(banca.Tcc.Aluno?.Nome),
+                ["TituloTcc"] = Codificar(banca.Tcc.Titulo),
+                ["NotaFinal"] = banca.NotaFinal.HasValue ? banca.NotaFinal.Value.ToString("0.0") : "Não informada"
+            };
+
+            if (!aprovado)
+            {
+                candidatos.AddRange(await ObterCandidatosCoordenadoresAsync());
+                chaveTemplate = "resultado-reprovado";
+                assunto = "Resultado final da banca: reprovado";
+                valores["MotivoRejeicao"] = Codificar(banca.Tcc.MotivoRejeicao) is { Length: > 0 } motivo ? motivo : "Não informado";
+            }
+
+            var destinatarios = ColetarEmails(candidatos.ToArray());
+            if (destinatarios.Count == 0) return;
+
+            var corpo = _renderer.Render(chaveTemplate, valores);
+
+            Enfileirar(destinatarios, assunto, corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de resultado de banca para a Banca {BancaId}.", bancaId);
+        }
+    }
+
+    private async Task<IEnumerable<(string Papel, string? Email)>> ObterCandidatosCoordenadoresAsync()
+    {
+        var coordenadores = await _context.Usuarios
+            .Where(u => u.Tipo == TipoUsuario.Coordenador && u.Ativo)
+            .Select(u => new { u.Nome, u.Email })
+            .ToListAsync();
+
+        return coordenadores.Select(c => ($"Coordenador {c.Nome}", (string?)c.Email));
+    }
+
+    /// <summary>
+    /// Filtra candidatos com e-mail vazio/nulo, logando um aviso individual por
+    /// destinatário descartado (Usuario.Email e MembroExterno.Email são NOT NULL no banco,
+    /// mas podem ser string vazia via PUT sem validação — ver docs/dados). Nunca lança.
+    /// </summary>
+    private List<string> ColetarEmails(params (string Papel, string? Email)[] candidatos)
+    {
+        var validos = new List<string>();
+
+        foreach (var (papel, email) in candidatos)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                _logger.LogWarning("Destinatário '{Papel}' sem e-mail válido; notificação não será enviada para ele.", papel);
+                continue;
+            }
+
+            validos.Add(email);
+        }
+
+        return validos.Distinct().ToList();
+    }
+
+    /// <summary>
+    /// Enfileira uma EmailMessage por destinatário (nunca todos no mesmo To:), para que
+    /// destinatários de uma mesma notificação (ex.: aluno, avaliadores externos, coordenadores)
+    /// não vejam o endereço de e-mail uns dos outros, e para que um endereço malformado
+    /// não descarte o envio para os demais.
+    /// </summary>
+    private void Enfileirar(IReadOnlyList<string> destinatarios, string assunto, string corpoHtml)
+    {
+        if (destinatarios.Count == 0)
+        {
+            _logger.LogWarning("Notificação '{Assunto}' sem destinatários válidos; e-mail não enviado.", assunto);
+            return;
+        }
+
+        foreach (var destinatario in destinatarios)
+        {
+            _queue.Enqueue(new EmailMessage(new[] { destinatario }, assunto, corpoHtml));
+        }
+    }
+
+    private static string Codificar(string? valor) => WebUtility.HtmlEncode(valor ?? string.Empty);
+}

--- a/TccManager.Api/TccManager.Api.csproj
+++ b/TccManager.Api/TccManager.Api.csproj
@@ -21,6 +21,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/TccManager.Api/TccManager.Api.csproj
+++ b/TccManager.Api/TccManager.Api.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />

--- a/TccManager.Api/TccManager.Api.csproj
+++ b/TccManager.Api/TccManager.Api.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
@@ -35,6 +36,10 @@
 
   <ItemGroup>
     <Folder Include="Migrations\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\EmailTemplates\*.html" />
   </ItemGroup>
 
 </Project>

--- a/TccManager.Api/appsettings.json
+++ b/TccManager.Api/appsettings.json
@@ -41,7 +41,9 @@
   "Jwt": {
     "Key": "",
     "Issuer": "TccManagerApi",
-    "Audience": "TccManagerClient"
+    "Audience": "TccManagerClient",
+    "AccessTokenMinutes": 15,
+    "RefreshTokenDays": 7
   },
   "Email": {
     "Smtp": {

--- a/TccManager.Api/appsettings.json
+++ b/TccManager.Api/appsettings.json
@@ -5,6 +5,35 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext", "WithMachineName" ],
+    "WriteTo": [
+      { "Name": "Console" },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "Logs/log-.txt",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 31,
+          "shared": true,
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{CorrelationId}] {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ]
+  },
+  "RateLimiting": {
+    "Login": {
+      "PermitLimit": 5,
+      "WindowSeconds": 60,
+      "QueueLimit": 0
+    }
+  },
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": ""

--- a/TccManager.Api/appsettings.json
+++ b/TccManager.Api/appsettings.json
@@ -42,5 +42,15 @@
     "Key": "",
     "Issuer": "TccManagerApi",
     "Audience": "TccManagerClient"
+  },
+  "Email": {
+    "Smtp": {
+      "Host": "",
+      "Port": 25,
+      "User": "",
+      "Password": "",
+      "UseSsl": false
+    },
+    "From": ""
   }
 }

--- a/TccManager.Client/Handlers/AuthTokenHandler.cs
+++ b/TccManager.Client/Handlers/AuthTokenHandler.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Blazored.LocalStorage;
+using TccManager.Client.Services;
+
+namespace TccManager.Client.Handlers;
+
+/// <summary>
+/// Interceptor central de 401 (RF06 — docs/arquitetura/2026-07-10-refresh-token-sessao.md §6).
+/// Anexa o bearer salvo no localStorage a toda requisição de saída (fonte única do header).
+/// Em endpoints de auth (login/refresh/logout) apenas repassa — bypass, para não disparar
+/// refresh a partir de um 401 de credencial inválida ou de um refresh já inválido. Em
+/// qualquer outro 401, aciona o <see cref="ITokenRefreshCoordinator"/> (single-flight) e,
+/// em caso de sucesso, reenvia a requisição original uma única vez com o novo bearer.
+/// </summary>
+public class AuthTokenHandler : DelegatingHandler
+{
+    private static readonly string[] RotasAuthSemRefresh =
+    {
+        "api/auth/login",
+        "api/auth/refresh",
+        "api/auth/logout"
+    };
+
+    private readonly ILocalStorageService _localStorage;
+    private readonly ITokenRefreshCoordinator _refreshCoordinator;
+
+    public AuthTokenHandler(ILocalStorageService localStorage, ITokenRefreshCoordinator refreshCoordinator)
+    {
+        _localStorage = localStorage;
+        _refreshCoordinator = refreshCoordinator;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var tokenUsado = await ObterTokenSalvoAsync(cancellationToken);
+        AnexarBearer(request, tokenUsado);
+
+        if (EhRotaAuth(request))
+        {
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        // P-C2: bufferiza o corpo ANTES do primeiro envio — um HttpContent já consumido
+        // não pode ser reenviado no retry.
+        var conteudoBufferizado = await BufferizarConteudoAsync(request, cancellationToken);
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            return response;
+        }
+
+        var refreshOk = await _refreshCoordinator.EnsureRefreshedAsync(tokenUsado ?? string.Empty);
+
+        if (!refreshOk)
+        {
+            return response;
+        }
+
+        response.Dispose();
+
+        var novoToken = await ObterTokenSalvoAsync(cancellationToken);
+
+        var retryRequest = ClonarRequisicao(request, conteudoBufferizado);
+        AnexarBearer(retryRequest, novoToken);
+
+        // Retry único (§6.4): se o retry ainda vier 401, propaga como sessão encerrada —
+        // não há nova tentativa de refresh a partir daqui.
+        return await base.SendAsync(retryRequest, cancellationToken);
+    }
+
+    private async Task<string?> ObterTokenSalvoAsync(CancellationToken cancellationToken)
+    {
+        var token = await _localStorage.GetItemAsStringAsync("authToken", cancellationToken);
+        return token?.Replace("\"", string.Empty);
+    }
+
+    private static void AnexarBearer(HttpRequestMessage request, string? token)
+    {
+        request.Headers.Authorization = string.IsNullOrWhiteSpace(token)
+            ? null
+            : new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    private static bool EhRotaAuth(HttpRequestMessage request)
+    {
+        var path = request.RequestUri?.AbsolutePath.Trim('/').ToLowerInvariant() ?? string.Empty;
+        return RotasAuthSemRefresh.Any(rota => path.EndsWith(rota, StringComparison.Ordinal));
+    }
+
+    private static async Task<byte[]?> BufferizarConteudoAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (request.Content == null)
+            return null;
+
+        return await request.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+
+    private static HttpRequestMessage ClonarRequisicao(HttpRequestMessage original, byte[]? conteudoBufferizado)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version
+        };
+
+        foreach (var header in original.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (conteudoBufferizado != null && original.Content != null)
+        {
+            var novoConteudo = new ByteArrayContent(conteudoBufferizado);
+            foreach (var header in original.Content.Headers)
+            {
+                novoConteudo.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            clone.Content = novoConteudo;
+        }
+
+        return clone;
+    }
+}

--- a/TccManager.Client/Layout/NavMenu.razor
+++ b/TccManager.Client/Layout/NavMenu.razor
@@ -1,10 +1,12 @@
 ﻿@using Microsoft.AspNetCore.Components.Authorization
 @using TccManager.Client.Providers
 @using Blazored.LocalStorage
+@using TccManager.Shared.DTOs
 
 @inject AuthenticationStateProvider AuthStateProvider
 @inject ILocalStorageService LocalStorage
 @inject NavigationManager Navigation
+@inject IHttpClientFactory HttpClientFactory
 
 <div class="d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px; height: 100vh;">
 
@@ -108,7 +110,27 @@
 @code {
     private async Task Logout()
     {
+        // RF05/§6.7: notifica o servidor para revogar o refresh token da sessão antes de
+        // limpar o estado local. Best-effort — falha de rede aqui não deve impedir o
+        // logout local, apenas é registrada.
+        try
+        {
+            var refreshToken = await LocalStorage.GetItemAsStringAsync("refreshToken");
+            refreshToken = refreshToken?.Replace("\"", string.Empty);
+
+            if (!string.IsNullOrWhiteSpace(refreshToken))
+            {
+                var authRawClient = HttpClientFactory.CreateClient("AuthRaw");
+                await authRawClient.PostAsJsonAsync("api/auth/logout", new LogoutRequestDto { RefreshToken = refreshToken });
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Falha ao notificar logout ao servidor (best-effort): {ex.Message}");
+        }
+
         await LocalStorage.RemoveItemAsync("authToken");
+        await LocalStorage.RemoveItemAsync("refreshToken");
         ((CustomAuthStateProvider)AuthStateProvider).NotifyUserLogout();
         Navigation.NavigateTo("/login");
     }

--- a/TccManager.Client/Pages/Login.razor
+++ b/TccManager.Client/Pages/Login.razor
@@ -51,9 +51,21 @@
 </div>
 
 @code {
+    [SupplyParameterFromQuery(Name = "expirado")]
+    [Parameter]
+    public string? Expirado { get; set; }
+
     private LoginDto loginModel = new();
     private string mensagemErro = string.Empty;
     private bool carregando = false;
+
+    protected override void OnInitialized()
+    {
+        if (Expirado == "1")
+        {
+            mensagemErro = "Sua sessão expirou. Faça login novamente.";
+        }
+    }
 
     private async Task HandleLogin()
     {
@@ -66,6 +78,7 @@
             {
                 var resultado = await response.Content.ReadFromJsonAsync<LoginResponseDto>();
                 await LocalStorage.SetItemAsync("authToken", resultado!.Token);
+                await LocalStorage.SetItemAsync("refreshToken", resultado.RefreshToken);
                 AuthStateProvider.NotifyUserAuthentication(resultado.Token);
 
                 Navigation.NavigateTo("/");
@@ -75,9 +88,9 @@
                 mensagemErro = "Credenciais inválidas. Tente novamente.";
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            mensagemErro = $"Ocorreu um erro: {ex.Message}";
+            mensagemErro = "Não foi possível entrar. Tente novamente em instantes.";
         }
         finally
         {

--- a/TccManager.Client/Program.cs
+++ b/TccManager.Client/Program.cs
@@ -4,16 +4,14 @@ using TccManager.Client;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Authorization;
 using TccManager.Client.Providers;
+using TccManager.Client.Handlers;
+using TccManager.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-
-builder.Services.AddScoped(sp => new HttpClient
-{
-    BaseAddress = new Uri(builder.Configuration["ApiBaseUrl"] ?? throw new Exception("URL da API n�o configurada!"))
-});
+var apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? throw new Exception("URL da API não configurada!");
 
 builder.Services.AddBlazoredLocalStorage();
 
@@ -23,5 +21,23 @@ builder.Services.AddScoped<CustomAuthStateProvider>();
 
 builder.Services.AddScoped<AuthenticationStateProvider>(provider =>
     provider.GetRequiredService<CustomAuthStateProvider>());
+
+builder.Services.AddScoped<ISessionEndedHandler, SessionEndedHandler>();
+builder.Services.AddScoped<ITokenRefreshCoordinator, TokenRefreshCoordinator>();
+
+builder.Services.AddTransient<AuthTokenHandler>();
+
+// Cliente "cru", sem o AuthTokenHandler — usado exclusivamente pelo handler/coordenador
+// para chamar /api/auth/refresh e /api/auth/logout, evitando recursão (§6.1 da
+// arquitetura: um 401 vindo do próprio /refresh nunca reentra no interceptor).
+builder.Services.AddHttpClient("AuthRaw", c => c.BaseAddress = new Uri(apiBaseUrl));
+
+// Cliente "Api", com o AuthTokenHandler no pipeline.
+builder.Services.AddHttpClient("Api", c => c.BaseAddress = new Uri(apiBaseUrl))
+    .AddHttpMessageHandler<AuthTokenHandler>();
+
+// Mantém "@inject HttpClient" funcionando em todas as páginas, agora já com o handler
+// no pipeline por trás (nenhuma página precisa ser alterada).
+builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("Api"));
 
 await builder.Build().RunAsync();

--- a/TccManager.Client/Providers/CustomAuthStateProvider.cs
+++ b/TccManager.Client/Providers/CustomAuthStateProvider.cs
@@ -1,19 +1,25 @@
-﻿using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using TccManager.Client.Services;
 
 namespace TccManager.Client.Providers;
+
 public class CustomAuthStateProvider : AuthenticationStateProvider
 {
     private readonly ILocalStorageService _localStorage;
-    private readonly HttpClient _http;
+    private readonly IServiceProvider _serviceProvider;
 
-    public CustomAuthStateProvider(ILocalStorageService localStorage, HttpClient http)
+    // ITokenRefreshCoordinator é resolvido sob demanda (via IServiceProvider) em vez de
+    // injetado diretamente no construtor: o coordenador, por sua vez, depende deste
+    // provider (para chamar NotifyUserAuthentication após renovar — §6.3 da
+    // arquitetura), então a injeção direta nos dois sentidos formaria um ciclo de DI.
+    public CustomAuthStateProvider(ILocalStorageService localStorage, IServiceProvider serviceProvider)
     {
         _localStorage = localStorage;
-        _http = http;
+        _serviceProvider = serviceProvider;
     }
 
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
@@ -25,35 +31,36 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
         if (string.IsNullOrWhiteSpace(token))
             return anonymousState;
 
-        token = token.Replace("\"", "");
+        token = token.Replace("\"", string.Empty);
 
-        var claims = ParseClaimsFromJwt(token);
-
-        var expClaim = claims.FirstOrDefault(c => c.Type == "exp");
-        if (expClaim != null && long.TryParse(expClaim.Value, out long expTime))
+        if (EstaExpirado(token))
         {
-            var dataExpiracao = DateTimeOffset.FromUnixTimeSeconds(expTime).UtcDateTime;
+            // P-C1: o access token expirou, mas pode existir um refresh token ainda
+            // válido — tenta renovar (reaproveitando o mesmo coordenador single-flight
+            // usado pelo handler de 401) antes de declarar a sessão anônima, evitando
+            // deslogar prematuramente uma sessão ainda renovável apenas por navegação.
+            var refreshCoordinator = _serviceProvider.GetRequiredService<ITokenRefreshCoordinator>();
+            var refreshOk = await refreshCoordinator.EnsureRefreshedAsync(token);
 
-            if (dataExpiracao <= DateTime.UtcNow)
-            {
-                await _localStorage.RemoveItemAsync("authToken");
-                _http.DefaultRequestHeaders.Authorization = null;
+            if (!refreshOk)
                 return anonymousState;
-            }
+
+            var tokenRenovado = await _localStorage.GetItemAsStringAsync("authToken");
+            if (string.IsNullOrWhiteSpace(tokenRenovado))
+                return anonymousState;
+
+            token = tokenRenovado.Replace("\"", string.Empty);
         }
 
-        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var identity = new ClaimsIdentity(claims, "jwt"); 
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
         var usuario = new ClaimsPrincipal(identity);
 
         return new AuthenticationState(usuario);
     }
 
-    public void NotifyUserAuthentication(string token) 
+    public void NotifyUserAuthentication(string token)
     {
-        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
         var claims = ParseClaimsFromJwt(token);
         var identity = new ClaimsIdentity(claims, "jwt");
         var usuario = new ClaimsPrincipal(identity);
@@ -63,23 +70,44 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 
     public void NotifyUserLogout()
     {
-        _http.DefaultRequestHeaders.Authorization = null;
-
         var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
 
         NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(anonymousUser)));
     }
 
-    private IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
+    private static bool EstaExpirado(string token)
+    {
+        var claims = ParseClaimsFromJwt(token);
+        var expClaim = claims.FirstOrDefault(c => c.Type == "exp");
+
+        if (expClaim == null || !long.TryParse(expClaim.Value, out var expTime))
+            return false;
+
+        var dataExpiracao = DateTimeOffset.FromUnixTimeSeconds(expTime).UtcDateTime;
+        return dataExpiracao <= DateTime.UtcNow;
+    }
+
+    private static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
     {
         var claims = new List<Claim>();
-        var payload = jwt.Split('.')[1];
-        var jsonBytes = ParseBase64WithoutPadding(payload);
-        var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
 
-        if (keyValuePairs != null) 
+        Dictionary<string, object>? keyValuePairs;
+        try
         {
-            foreach (var kvp in keyValuePairs) 
+            var payload = jwt.Split('.')[1];
+            var jsonBytes = ParseBase64WithoutPadding(payload);
+            keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
+        }
+        catch (Exception ex) when (ex is IndexOutOfRangeException or FormatException or JsonException)
+        {
+            // Token malformado em localStorage (ex.: corrompido manualmente): trata como
+            // anônimo em vez de propagar exceção para GetAuthenticationStateAsync.
+            return claims;
+        }
+
+        if (keyValuePairs != null)
+        {
+            foreach (var kvp in keyValuePairs)
             {
                 var value = kvp.Value.ToString() ?? "";
                 var claimType = kvp.Key;
@@ -92,8 +120,8 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
                 {
                     claimType = ClaimTypes.Name;
                 }
-                else if (claimType == "nameid" || claimType.Contains("/claims/nameid")) 
-                { 
+                else if (claimType == "nameid" || claimType.Contains("/claims/nameid"))
+                {
                     claimType = ClaimTypes.NameIdentifier;
                 }
 
@@ -116,17 +144,17 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
                         Console.WriteLine($"Erro ao desserializar o valor do claim '{claimType}': {value}");
                     }
                 }
-                else 
-                { 
+                else
+                {
                     claims.Add(new Claim(claimType, value));
                 }
-            }        
+            }
         }
 
         return claims;
     }
 
-    private byte[] ParseBase64WithoutPadding(string base64)
+    private static byte[] ParseBase64WithoutPadding(string base64)
     {
         switch (base64.Length % 4)
         {

--- a/TccManager.Client/Services/ISessionEndedHandler.cs
+++ b/TccManager.Client/Services/ISessionEndedHandler.cs
@@ -1,0 +1,11 @@
+namespace TccManager.Client.Services;
+
+/// <summary>
+/// Fluxo de encerramento de sessão (RF07/RF08 — §6.5 da arquitetura): limpa o
+/// localStorage, notifica o estado de autenticação como anônimo e redireciona para
+/// <c>/login?expirado=1</c>, onde a tela exibe a mensagem de sessão expirada.
+/// </summary>
+public interface ISessionEndedHandler
+{
+    Task EncerrarSessaoAsync();
+}

--- a/TccManager.Client/Services/ITokenRefreshCoordinator.cs
+++ b/TccManager.Client/Services/ITokenRefreshCoordinator.cs
@@ -1,0 +1,18 @@
+namespace TccManager.Client.Services;
+
+/// <summary>
+/// Single-flight de renovação de sessão (§6.3 da arquitetura). Garante que múltiplas
+/// requisições recebendo 401 ao mesmo tempo disparem apenas uma chamada real a
+/// <c>/api/auth/refresh</c> — as demais reaproveitam o token renovado pela primeira.
+/// </summary>
+public interface ITokenRefreshCoordinator
+{
+    /// <summary>
+    /// Garante que a sessão esteja renovada. <paramref name="tokenUsado"/> é o access
+    /// token que estava em uso quando o 401 ocorreu (ou o token expirado detectado na
+    /// navegação, ver P-C1). Retorna <c>true</c> se, ao final, há um access token válido
+    /// no localStorage (seja porque outra chamada concorrente já renovou, seja porque este
+    /// chamador renovou agora); <c>false</c> se o refresh falhou (sessão encerrada).
+    /// </summary>
+    Task<bool> EnsureRefreshedAsync(string tokenUsado);
+}

--- a/TccManager.Client/Services/SessionEndedHandler.cs
+++ b/TccManager.Client/Services/SessionEndedHandler.cs
@@ -1,0 +1,32 @@
+using Blazored.LocalStorage;
+using Microsoft.AspNetCore.Components;
+using TccManager.Client.Providers;
+
+namespace TccManager.Client.Services;
+
+public class SessionEndedHandler : ISessionEndedHandler
+{
+    private readonly ILocalStorageService _localStorage;
+    private readonly NavigationManager _navigation;
+    private readonly CustomAuthStateProvider _authStateProvider;
+
+    public SessionEndedHandler(
+        ILocalStorageService localStorage,
+        NavigationManager navigation,
+        CustomAuthStateProvider authStateProvider)
+    {
+        _localStorage = localStorage;
+        _navigation = navigation;
+        _authStateProvider = authStateProvider;
+    }
+
+    public async Task EncerrarSessaoAsync()
+    {
+        await _localStorage.RemoveItemAsync("authToken");
+        await _localStorage.RemoveItemAsync("refreshToken");
+
+        _authStateProvider.NotifyUserLogout();
+
+        _navigation.NavigateTo("/login?expirado=1");
+    }
+}

--- a/TccManager.Client/Services/TokenRefreshCoordinator.cs
+++ b/TccManager.Client/Services/TokenRefreshCoordinator.cs
@@ -1,0 +1,89 @@
+using System.Net.Http.Json;
+using Blazored.LocalStorage;
+using TccManager.Client.Providers;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Client.Services;
+
+public class TokenRefreshCoordinator : ITokenRefreshCoordinator
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILocalStorageService _localStorage;
+    private readonly ISessionEndedHandler _sessionEndedHandler;
+    private readonly CustomAuthStateProvider _authStateProvider;
+
+    public TokenRefreshCoordinator(
+        IHttpClientFactory httpClientFactory,
+        ILocalStorageService localStorage,
+        ISessionEndedHandler sessionEndedHandler,
+        CustomAuthStateProvider authStateProvider)
+    {
+        _httpClientFactory = httpClientFactory;
+        _localStorage = localStorage;
+        _sessionEndedHandler = sessionEndedHandler;
+        _authStateProvider = authStateProvider;
+    }
+
+    public async Task<bool> EnsureRefreshedAsync(string tokenUsado)
+    {
+        await _semaphore.WaitAsync();
+        try
+        {
+            var tokenAtual = await ObterItemSemAspasAsync("authToken");
+
+            // Outra requisição concorrente já renovou a sessão enquanto este chamador
+            // esperava o lock — não chama o servidor de novo, apenas reaproveita.
+            if (!string.IsNullOrEmpty(tokenAtual) && tokenAtual != tokenUsado)
+            {
+                return true;
+            }
+
+            var refreshTokenAtual = await ObterItemSemAspasAsync("refreshToken");
+
+            if (string.IsNullOrWhiteSpace(refreshTokenAtual))
+            {
+                await _sessionEndedHandler.EncerrarSessaoAsync();
+                return false;
+            }
+
+            var client = _httpClientFactory.CreateClient("AuthRaw");
+            var response = await client.PostAsJsonAsync("api/auth/refresh", new RefreshRequestDto
+            {
+                RefreshToken = refreshTokenAtual
+            });
+
+            if (!response.IsSuccessStatusCode)
+            {
+                await _sessionEndedHandler.EncerrarSessaoAsync();
+                return false;
+            }
+
+            var par = await response.Content.ReadFromJsonAsync<TokenPairDto>();
+
+            if (par == null || string.IsNullOrWhiteSpace(par.Token) || string.IsNullOrWhiteSpace(par.RefreshToken))
+            {
+                await _sessionEndedHandler.EncerrarSessaoAsync();
+                return false;
+            }
+
+            await _localStorage.SetItemAsync("authToken", par.Token);
+            await _localStorage.SetItemAsync("refreshToken", par.RefreshToken);
+
+            _authStateProvider.NotifyUserAuthentication(par.Token);
+
+            return true;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private async Task<string?> ObterItemSemAspasAsync(string chave)
+    {
+        var valor = await _localStorage.GetItemAsStringAsync(chave);
+        return valor?.Replace("\"", string.Empty);
+    }
+}

--- a/TccManager.Client/TccManager.Client.csproj
+++ b/TccManager.Client/TccManager.Client.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TccManager.Shared/DTOs/LoginResponseDto.cs
+++ b/TccManager.Shared/DTOs/LoginResponseDto.cs
@@ -3,6 +3,7 @@
 public class LoginResponseDto
 {
     public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
     public string Nome { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
 }

--- a/TccManager.Shared/DTOs/LogoutRequestDto.cs
+++ b/TccManager.Shared/DTOs/LogoutRequestDto.cs
@@ -1,0 +1,6 @@
+namespace TccManager.Shared.DTOs;
+
+public class LogoutRequestDto
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/TccManager.Shared/DTOs/RefreshRequestDto.cs
+++ b/TccManager.Shared/DTOs/RefreshRequestDto.cs
@@ -1,0 +1,6 @@
+namespace TccManager.Shared.DTOs;
+
+public class RefreshRequestDto
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/TccManager.Shared/DTOs/TokenPairDto.cs
+++ b/TccManager.Shared/DTOs/TokenPairDto.cs
@@ -1,0 +1,8 @@
+namespace TccManager.Shared.DTOs;
+
+public class TokenPairDto
+{
+    public string Token { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTime ExpiresAtUtc { get; set; }
+}

--- a/TccManager.Shared/Models/RefreshToken.cs
+++ b/TccManager.Shared/Models/RefreshToken.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TccManager.Shared.Models;
+
+[Table("refresh_tokens")]
+public class RefreshToken
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int UsuarioId { get; set; }
+    [ForeignKey("UsuarioId")]
+    public Usuario? Usuario { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string TokenHash { get; set; } = string.Empty;
+
+    public DateTime ExpiresAtUtc { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime? RevokedAtUtc { get; set; }
+
+    [MaxLength(64)]
+    public string? ReplacedByTokenHash { get; set; }
+}

--- a/TccManager.Tests/Configuration/RateLimitingLoginTests.cs
+++ b/TccManager.Tests/Configuration/RateLimitingLoginTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Json;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Configuration;
+
+/// <summary>
+/// Testes de integração da política de rate limiting "login" (S2).
+///
+/// Isolamento entre casos: cada teste cria sua própria instância de
+/// <see cref="TccApiFactory"/> (portanto seu próprio host e sua própria instância do
+/// PartitionedRateLimiter registrada na DI daquele host). Como o limitador é um serviço
+/// por host, o estado de contagem NÃO é compartilhado entre factories distintas — o que
+/// garante que o limite consumido em um teste não interfira em outro.
+/// </summary>
+public class RateLimitingLoginTests
+{
+    private const string RotaLogin = "/api/auth/login";
+    private const string SenhaValida = "SenhaValida123";
+
+    private static LoginDto CredencialInvalida() =>
+        new() { Email = "naoexiste@teste.com", Senha = "errada" };
+
+    private static async Task SemearUsuarioValido(TccApiFactory factory, string email)
+    {
+        using var context = factory.CriarContextoDireto();
+        context.Usuarios.Add(new Usuario
+        {
+            Nome = "Usuario Valido",
+            Email = email,
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword(SenhaValida),
+            Tipo = TipoUsuario.Aluno,
+            Ativo = true
+        });
+        await context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task SextaTentativaDentroDaJanela_DeveRetornar429ComRetryAfter()
+    {
+        // Arrange
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var dto = CredencialInvalida();
+
+        // Act — as 5 primeiras tentativas passam pelo limitador e chegam na lógica de auth
+        for (var i = 1; i <= 5; i++)
+        {
+            var permitida = await client.PostAsJsonAsync(RotaLogin, dto);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, permitida.StatusCode);
+        }
+
+        // 6ª tentativa dentro da mesma janela → deve ser bloqueada
+        var bloqueada = await client.PostAsJsonAsync(RotaLogin, dto);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.TooManyRequests, bloqueada.StatusCode);
+        Assert.True(bloqueada.Headers.Contains("Retry-After"),
+            "A resposta 429 deve conter o header Retry-After.");
+
+        var retryAfter = bloqueada.Headers.GetValues("Retry-After").First();
+        Assert.True(int.TryParse(retryAfter, out var segundos),
+            $"Retry-After deveria ser um inteiro em segundos, mas foi '{retryAfter}'.");
+        Assert.InRange(segundos, 1, 60);
+    }
+
+    [Fact]
+    public async Task CredenciaisValidasEInvalidas_ContamIgualmenteParaOLimite()
+    {
+        // Arrange — o rate limiter atua ANTES da lógica de autenticação, logo tanto um 200
+        // (login válido) quanto um 401 (credencial inválida) consomem uma permissão.
+        var factory = new TccApiFactory();
+        await SemearUsuarioValido(factory, "valido@teste.com");
+        var client = factory.CreateClient();
+
+        var valida = new LoginDto { Email = "valido@teste.com", Senha = SenhaValida };
+        var invalida = CredencialInvalida();
+
+        // Act — 5 requisições intercalando válidas e inválidas
+        var sequencia = new[] { valida, invalida, valida, invalida, valida };
+        var statusObtidos = new List<HttpStatusCode>();
+        foreach (var corpo in sequencia)
+        {
+            var resp = await client.PostAsJsonAsync(RotaLogin, corpo);
+            statusObtidos.Add(resp.StatusCode);
+        }
+
+        // 6ª requisição (uma credencial VÁLIDA) já deve ser bloqueada, provando que os
+        // sucessos anteriores também contaram para o limite.
+        var sextaValida = await client.PostAsJsonAsync(RotaLogin, valida);
+
+        // Assert
+        Assert.DoesNotContain(HttpStatusCode.TooManyRequests, statusObtidos);
+        Assert.Contains(HttpStatusCode.OK, statusObtidos);            // ao menos um login válido passou (200)
+        Assert.Contains(HttpStatusCode.Unauthorized, statusObtidos);  // ao menos uma credencial inválida passou (401)
+        Assert.Equal(HttpStatusCode.TooManyRequests, sextaValida.StatusCode);
+    }
+
+    [Fact]
+    public async Task DentroDoLimite_CincoTentativas_NenhumaEhBloqueada()
+    {
+        // Arrange
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var dto = CredencialInvalida();
+
+        // Act & Assert — exatamente 5 (PermitLimit) devem ser permitidas
+        for (var i = 1; i <= 5; i++)
+        {
+            var resp = await client.PostAsJsonAsync(RotaLogin, dto);
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+    }
+}

--- a/TccManager.Tests/Controllers/AuthController_RefreshToken_Tests.cs
+++ b/TccManager.Tests/Controllers/AuthController_RefreshToken_Tests.cs
@@ -1,0 +1,306 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Testes de integração da S4 (Refresh Token / Controle de Sessão): login com emissão de
+/// refresh token, sessão única (login revoga sessões anteriores), rotação em /api/auth/refresh
+/// e revogação em /api/auth/logout.
+///
+/// Isolamento: cada teste instancia sua própria <see cref="TccApiFactory"/> (host + banco
+/// InMemory + PartitionedRateLimiter próprios). Isso garante DB limpo e, importante para esta
+/// suíte, que o rate limiter "login" (compartilhado por /login e /refresh — 5 req/janela por IP)
+/// não some chamadas entre testes distintos. Cada teste mantém no máximo 4 chamadas às rotas
+/// limitadas para nunca esbarrar no limite de 5.
+/// </summary>
+public class AuthController_RefreshToken_Tests
+{
+    private const string RotaLogin = "/api/auth/login";
+    private const string RotaRefresh = "/api/auth/refresh";
+    private const string RotaLogout = "/api/auth/logout";
+    private const string SenhaValida = "SenhaValida123";
+
+    private static async Task<Usuario> SemearUsuario(TccApiFactory factory, string email = "aluno@teste.com")
+    {
+        using var context = factory.CriarContextoDireto();
+        var usuario = new Usuario
+        {
+            Nome = "Aluno Teste",
+            Email = email,
+            SenhaHash = BCrypt.Net.BCrypt.HashPassword(SenhaValida),
+            Tipo = TipoUsuario.Aluno,
+            Ativo = true
+        };
+        context.Usuarios.Add(usuario);
+        await context.SaveChangesAsync();
+        return usuario;
+    }
+
+    /// <summary>
+    /// Replica exatamente o algoritmo de <c>AuthTokenService.CalcularHash</c> (SHA-256 em hex
+    /// minúsculo) para permitir semear refresh tokens diretamente no banco em cenários que não
+    /// podem ser produzidos por um fluxo HTTP normal (expirado, revogado sem passar por logout).
+    /// </summary>
+    private static string CalcularHash(string valor)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(valor));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    private static async Task<LoginResponseDto> FazerLogin(HttpClient client, string email = "aluno@teste.com")
+    {
+        var resp = await client.PostAsJsonAsync(RotaLogin, new LoginDto { Email = email, Senha = SenhaValida });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<LoginResponseDto>();
+        Assert.NotNull(dto);
+        return dto!;
+    }
+
+    // ─────────────────────────── Login ───────────────────────────
+
+    [Fact]
+    public async Task Login_CredenciaisValidas_RetornaJwtERefreshToken()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory, "login@teste.com");
+        var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync(RotaLogin,
+            new LoginDto { Email = "login@teste.com", Senha = SenhaValida });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var dto = await resp.Content.ReadFromJsonAsync<LoginResponseDto>();
+        Assert.NotNull(dto);
+        Assert.False(string.IsNullOrWhiteSpace(dto!.Token));
+        // JWT tem 3 segmentos separados por ponto (header.payload.signature).
+        Assert.Equal(3, dto.Token.Split('.').Length);
+        Assert.False(string.IsNullOrWhiteSpace(dto.RefreshToken));
+        Assert.Equal("Aluno Teste", dto.Nome);
+        Assert.Equal("login@teste.com", dto.Email);
+    }
+
+    [Fact]
+    public async Task Login_PersisteRefreshTokenComoHashNaoOValorBruto()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var dto = await FazerLogin(client);
+
+        using var context = factory.CriarContextoDireto();
+        var persistido = context.RefreshTokens.SingleOrDefault();
+        Assert.NotNull(persistido);
+        // O valor bruto nunca é gravado; grava-se apenas o hash SHA-256.
+        Assert.NotEqual(dto.RefreshToken, persistido!.TokenHash);
+        Assert.Equal(CalcularHash(dto.RefreshToken), persistido.TokenHash);
+        Assert.Null(persistido.RevokedAtUtc);
+    }
+
+    // ──────────────────── Sessão única (RF04) ────────────────────
+
+    [Fact]
+    public async Task LoginDuasVezes_MesmoUsuario_RevogaRefreshTokenDaPrimeiraSessao()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var primeira = await FazerLogin(client);   // sessão 1
+        var segunda = await FazerLogin(client);    // sessão 2 — deve revogar a 1
+
+        Assert.NotEqual(primeira.RefreshToken, segunda.RefreshToken);
+
+        // O refresh token da primeira sessão não pode mais ser usado.
+        var refreshAntigo = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = primeira.RefreshToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, refreshAntigo.StatusCode);
+
+        // O refresh token da sessão atual continua válido.
+        var refreshAtual = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = segunda.RefreshToken });
+        Assert.Equal(HttpStatusCode.OK, refreshAtual.StatusCode);
+    }
+
+    // ──────────────────── Refresh / rotação (RF03) ────────────────────
+
+    [Fact]
+    public async Task Refresh_TokenValido_RetornaNovoParERotacionaOAntigo()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var login = await FazerLogin(client);
+
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = login.RefreshToken });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var par = await resp.Content.ReadFromJsonAsync<TokenPairDto>();
+        Assert.NotNull(par);
+        Assert.False(string.IsNullOrWhiteSpace(par!.Token));
+        Assert.Equal(3, par.Token.Split('.').Length);
+        Assert.False(string.IsNullOrWhiteSpace(par.RefreshToken));
+        // Rotação: o novo refresh token é diferente do apresentado.
+        Assert.NotEqual(login.RefreshToken, par.RefreshToken);
+        Assert.True(par.ExpiresAtUtc > DateTime.UtcNow);
+
+        // O refresh token antigo deixa de funcionar após a rotação.
+        var reuso = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = login.RefreshToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, reuso.StatusCode);
+    }
+
+    [Fact]
+    public async Task Refresh_MarcaTokenAntigoComoRevogadoEApontaParaONovo()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var login = await FazerLogin(client);
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = login.RefreshToken });
+        var par = await resp.Content.ReadFromJsonAsync<TokenPairDto>();
+
+        using var context = factory.CriarContextoDireto();
+        var hashAntigo = CalcularHash(login.RefreshToken);
+        var hashNovo = CalcularHash(par!.RefreshToken);
+
+        var antigo = context.RefreshTokens.Single(rt => rt.TokenHash == hashAntigo);
+        Assert.NotNull(antigo.RevokedAtUtc);
+        Assert.Equal(hashNovo, antigo.ReplacedByTokenHash);
+
+        var novo = context.RefreshTokens.Single(rt => rt.TokenHash == hashNovo);
+        Assert.Null(novo.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Refresh_TokenInexistente_Retorna401()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = Guid.NewGuid().ToString() });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Refresh_TokenVazio_Retorna401()
+    {
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = "" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Refresh_TokenExpirado_Retorna401()
+    {
+        var factory = new TccApiFactory();
+        var usuario = await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var refreshBruto = Guid.NewGuid().ToString();
+        using (var context = factory.CriarContextoDireto())
+        {
+            context.RefreshTokens.Add(new RefreshToken
+            {
+                UsuarioId = usuario.Id,
+                TokenHash = CalcularHash(refreshBruto),
+                CreatedAtUtc = DateTime.UtcNow.AddDays(-8),
+                ExpiresAtUtc = DateTime.UtcNow.AddMinutes(-1), // já expirado
+                RevokedAtUtc = null
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = refreshBruto });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Refresh_TokenJaRevogado_Retorna401()
+    {
+        var factory = new TccApiFactory();
+        var usuario = await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var refreshBruto = Guid.NewGuid().ToString();
+        using (var context = factory.CriarContextoDireto())
+        {
+            context.RefreshTokens.Add(new RefreshToken
+            {
+                UsuarioId = usuario.Id,
+                TokenHash = CalcularHash(refreshBruto),
+                CreatedAtUtc = DateTime.UtcNow.AddMinutes(-5),
+                ExpiresAtUtc = DateTime.UtcNow.AddDays(7),
+                RevokedAtUtc = DateTime.UtcNow.AddMinutes(-1) // revogado, ainda não expirado
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var resp = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = refreshBruto });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    // ──────────────────── Logout (RF05) ────────────────────
+
+    [Fact]
+    public async Task Logout_RevogaRefreshToken_UsoPosteriorFalha()
+    {
+        var factory = new TccApiFactory();
+        await SemearUsuario(factory);
+        var client = factory.CreateClient();
+
+        var login = await FazerLogin(client);
+
+        var logout = await client.PostAsJsonAsync(RotaLogout,
+            new LogoutRequestDto { RefreshToken = login.RefreshToken });
+        Assert.Equal(HttpStatusCode.NoContent, logout.StatusCode);
+
+        // Após logout, o refresh token não pode mais ser usado.
+        var refresh = await client.PostAsJsonAsync(RotaRefresh,
+            new RefreshRequestDto { RefreshToken = login.RefreshToken });
+        Assert.Equal(HttpStatusCode.Unauthorized, refresh.StatusCode);
+
+        using var context = factory.CriarContextoDireto();
+        var persistido = context.RefreshTokens.Single(rt => rt.TokenHash == CalcularHash(login.RefreshToken));
+        Assert.NotNull(persistido.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task Logout_TokenInexistenteOuVazio_Idempotente_Retorna204()
+    {
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+
+        var inexistente = await client.PostAsJsonAsync(RotaLogout,
+            new LogoutRequestDto { RefreshToken = Guid.NewGuid().ToString() });
+        Assert.Equal(HttpStatusCode.NoContent, inexistente.StatusCode);
+
+        var vazio = await client.PostAsJsonAsync(RotaLogout,
+            new LogoutRequestDto { RefreshToken = "" });
+        Assert.Equal(HttpStatusCode.NoContent, vazio.StatusCode);
+    }
+}

--- a/TccManager.Tests/Controllers/NotificacaoIntegracao_Tests.cs
+++ b/TccManager.Tests/Controllers/NotificacaoIntegracao_Tests.cs
@@ -1,0 +1,200 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TccManager.Api.Services.Email;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Services.Email;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração leve dos pontos de disparo de notificação: substitui o IEmailQueue real
+/// por um FakeEmailQueue e confirma, através do pipeline HTTP completo, que (a) a resposta
+/// HTTP continua correta mesmo sem SMTP configurado e (b) a mensagem certa é enfileirada
+/// dentro do request (destinatários resolvidos do banco). Reaproveita o mesmo host único
+/// de TccApiFactory (mesma InstanceDb usada para seed e para o request).
+/// </summary>
+public class NotificacaoIntegracao_Tests
+{
+    private const int idCoordenador = 1;
+    private const int idAluno = 10;
+    private const int idOrientador = 20;
+    private const int idAvaliador1 = 21;
+    private const int idAvaliador2 = 22;
+
+    private sealed class FactoryComFilaFake : TccApiFactory
+    {
+        private readonly FakeEmailQueue _fila;
+
+        public FactoryComFilaFake(FakeEmailQueue fila) => _fila = fila;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IEmailQueue>();
+                services.AddSingleton<IEmailQueue>(_fila);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task AgendarBanca_RetornaSucesso_EEnfileiraEmailBancaAgendadaComTodosOsDestinatarios()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                new Usuario { Id = idAluno, Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true },
+                new Usuario { Id = idOrientador, Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+                new Usuario { Id = idAvaliador1, Nome = "Avaliador Um", Email = "aval1@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+                new Usuario { Id = idAvaliador2, Nome = "Avaliador Dois", Email = "aval2@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true });
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.AguardandoDefesa,
+                DataCriacao = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var dto = new AgendarBancaDto
+        {
+            DataHora = DateTime.Now.AddDays(7),
+            Local = "Sala 101",
+            ProfessoresIds = new List<int> { idAvaliador1, idAvaliador2 },
+            MembrosExternosIds = new List<int>()
+        };
+
+        var response = await client.PostAsJsonAsync("/api/coordenador/tcc/1/banca", dto);
+
+        response.EnsureSuccessStatusCode();
+
+        // Uma EmailMessage por destinatário (nunca todos no mesmo To:).
+        Assert.All(fila.Mensagens, m => Assert.Equal("Banca de TCC agendada", m.Assunto));
+        var destinatarios = DestinatariosDaFila(fila);
+        Assert.Equal(4, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.Contains("aval1@teste.com", destinatarios);
+        Assert.Contains("aval2@teste.com", destinatarios);
+    }
+
+    [Fact]
+    public async Task RegistrarResultadoBanca_Reprovado_EnfileiraEmailIncluindoCoordenadorAtivo()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                new Usuario { Id = idAluno, Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true },
+                new Usuario { Id = idOrientador, Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+                new Usuario { Id = 30, Nome = "Coordenador", Email = "coord@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Coordenador, Ativo = true });
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.AguardandoDefesa,
+                DataCriacao = DateTime.UtcNow
+            });
+            ctx.Entregas.Add(new Entrega { TccId = 1, Titulo = "Versão Final", ArquivoCaminho = "/x.pdf", Tipo = TipoEntrega.Final, DataEnvio = DateTime.UtcNow });
+            ctx.Banca.Add(new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(1), Local = "Sala" });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent((40.0m).ToString(CultureInfo.InvariantCulture)), "notaFinal" },
+            { new StringContent("Não atingiu a nota mínima."), "motivoReprovacao" }
+        };
+        var pdfFake = new ByteArrayContent(new byte[] { 0x25, 0x50, 0x44, 0x46 });
+        pdfFake.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(pdfFake, "arquivoAta", "ata.pdf");
+
+        var response = await client.PostAsync("/api/coordenador/banca/1/registrar-resultado", form);
+
+        response.EnsureSuccessStatusCode();
+
+        Assert.All(fila.Mensagens, m => Assert.Equal("Resultado final da banca: reprovado", m.Assunto));
+        var destinatarios = DestinatariosDaFila(fila);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.Contains("coord@teste.com", destinatarios);
+    }
+
+    [Fact]
+    public async Task RegistrarResultadoBanca_Aprovado_NaoIncluiCoordenadorNosDestinatarios()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                new Usuario { Id = idAluno, Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true },
+                new Usuario { Id = idOrientador, Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+                new Usuario { Id = 30, Nome = "Coordenador", Email = "coord@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Coordenador, Ativo = true });
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.AguardandoDefesa,
+                DataCriacao = DateTime.UtcNow
+            });
+            ctx.Banca.Add(new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(1), Local = "Sala" });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var form = new MultipartFormDataContent
+        {
+            { new StringContent((85.0m).ToString(CultureInfo.InvariantCulture)), "notaFinal" }
+        };
+        var pdfFake = new ByteArrayContent(new byte[] { 0x25, 0x50, 0x44, 0x46 });
+        pdfFake.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(pdfFake, "arquivoAta", "ata.pdf");
+
+        var response = await client.PostAsync("/api/coordenador/banca/1/registrar-resultado", form);
+
+        response.EnsureSuccessStatusCode();
+
+        Assert.All(fila.Mensagens, m => Assert.Equal("Resultado final da banca: aprovado", m.Assunto));
+        var destinatarios = DestinatariosDaFila(fila);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.DoesNotContain("coord@teste.com", destinatarios);
+    }
+
+    /// <summary>
+    /// Achata os destinatários da fila garantindo o novo contrato de privacidade: uma
+    /// EmailMessage por destinatário, cada uma com exatamente 1 e-mail no campo To:.
+    /// </summary>
+    private static List<string> DestinatariosDaFila(FakeEmailQueue fila)
+        => fila.Mensagens.Select(m => Assert.Single(m.Destinatarios)).ToList();
+}

--- a/TccManager.Tests/Controllers/OrientadorNotificacaoIntegracao_Tests.cs
+++ b/TccManager.Tests/Controllers/OrientadorNotificacaoIntegracao_Tests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TccManager.Api.Services.Email;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Services.Email;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração dos pontos de disparo de notificação do OrientadorController (AprovarProposta,
+/// RejeitarProposta, RegistrarFeedback e DarAceiteFinal). Substitui o IEmailQueue real por um
+/// FakeEmailQueue e confirma, através do pipeline HTTP completo, que (a) a resposta HTTP continua
+/// correta mesmo sem SMTP configurado e (b) a notificação certa é enfileirada dentro do request.
+/// Mesmo padrão de NotificacaoIntegracao_Tests (host único de TccApiFactory, InMemory).
+/// </summary>
+public class OrientadorNotificacaoIntegracao_Tests
+{
+    private const int idAluno = 10;
+    private const int idOrientador = 20;
+    private const int idCoordenador = 30;
+
+    private sealed class FactoryComFilaFake : TccApiFactory
+    {
+        private readonly FakeEmailQueue _fila;
+
+        public FactoryComFilaFake(FakeEmailQueue fila) => _fila = fila;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IEmailQueue>();
+                services.AddSingleton<IEmailQueue>(_fila);
+            });
+        }
+    }
+
+    private static Usuario NovoUsuario(int id, string nome, string email, TipoUsuario tipo, bool ativo = true)
+        => new() { Id = id, Nome = nome, Email = email, SenhaHash = "x", Tipo = tipo, Ativo = ativo };
+
+    private static List<string> DestinatariosDaFila(FakeEmailQueue fila)
+        => fila.Mensagens.Select(m => Assert.Single(m.Destinatarios)).ToList();
+
+    [Fact]
+    public async Task AprovarProposta_RetornaOk_EEnfileiraNotificacaoParaOAluno()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                NovoUsuario(idAluno, "Aluno", "aluno@teste.com", TipoUsuario.Aluno),
+                NovoUsuario(idOrientador, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                Status = StatusTcc.Pendente,
+                DataCriacao = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idOrientador, "Professor");
+
+        var response = await client.PostAsync("/api/orientador/propostas/1/aprovar", null);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var msg = Assert.Single(fila.Mensagens);
+        Assert.Equal("Proposta de TCC aprovada", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+
+        using var verifica = factory.CriarContextoDireto();
+        var tcc = await verifica.Tccs.FirstAsync(t => t.Id == 1);
+        Assert.Equal(StatusTcc.Aprovado, tcc.Status);
+        Assert.Equal(idOrientador, tcc.OrientadorId);
+    }
+
+    [Fact]
+    public async Task RejeitarProposta_RetornaOk_EEnfileiraNotificacaoParaOAluno()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                NovoUsuario(idAluno, "Aluno", "aluno@teste.com", TipoUsuario.Aluno),
+                NovoUsuario(idOrientador, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                Status = StatusTcc.Pendente,
+                DataCriacao = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idOrientador, "Professor");
+        var dto = new RejeicaoDto { Motivo = "Escopo muito amplo para o prazo." };
+
+        var response = await client.PostAsJsonAsync("/api/orientador/propostas/1/rejeitar", dto);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var msg = Assert.Single(fila.Mensagens);
+        Assert.Equal("Proposta de TCC rejeitada", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+
+        using var verifica = factory.CriarContextoDireto();
+        var tcc = await verifica.Tccs.FirstAsync(t => t.Id == 1);
+        Assert.Equal(StatusTcc.Reprovado, tcc.Status);
+    }
+
+    [Fact]
+    public async Task RegistrarFeedback_RetornaOk_EEnfileiraNotificacaoParaOAluno()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                NovoUsuario(idAluno, "Aluno", "aluno@teste.com", TipoUsuario.Aluno),
+                NovoUsuario(idOrientador, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.EmAndamento,
+                DataCriacao = DateTime.UtcNow
+            });
+            ctx.Entregas.Add(new Entrega
+            {
+                Id = 7,
+                TccId = 1,
+                Titulo = "Entrega Parcial",
+                ArquivoCaminho = "/x.pdf",
+                Tipo = TipoEntrega.Parcial,
+                DataEnvio = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idOrientador, "Professor");
+        var dto = new FeedbackDto { Feedback = "Bom trabalho, ajuste as referências.", Nota = 8.5m };
+
+        var response = await client.PostAsJsonAsync("/api/orientador/entregas/7/feedback", dto);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var msg = Assert.Single(fila.Mensagens);
+        Assert.Equal("Feedback registrado na sua entrega", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+
+        using var verifica = factory.CriarContextoDireto();
+        var entrega = await verifica.Entregas.FirstAsync(e => e.Id == 7);
+        Assert.Equal(8.5m, entrega.Nota);
+    }
+
+    [Fact]
+    public async Task DarAceiteFinal_ComEntregaFinal_RetornaOk_EEnfileiraNotificacaoParaAlunoECoordenadores()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                NovoUsuario(idAluno, "Aluno", "aluno@teste.com", TipoUsuario.Aluno),
+                NovoUsuario(idOrientador, "Orientador", "orient@teste.com", TipoUsuario.Professor),
+                NovoUsuario(idCoordenador, "Coordenador", "coord@teste.com", TipoUsuario.Coordenador));
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.EmAndamento,
+                DataCriacao = DateTime.UtcNow
+            });
+            ctx.Entregas.Add(new Entrega
+            {
+                Id = 8,
+                TccId = 1,
+                Titulo = "Versão Final",
+                ArquivoCaminho = "/final.pdf",
+                Tipo = TipoEntrega.Final,
+                DataEnvio = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idOrientador, "Professor");
+
+        var response = await client.PostAsync("/api/orientador/tcc/1/aceite-final", null);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.All(fila.Mensagens, m => Assert.Equal("Aceite final concedido", m.Assunto));
+        var destinatarios = DestinatariosDaFila(fila);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("coord@teste.com", destinatarios);
+
+        using var verifica = factory.CriarContextoDireto();
+        var tcc = await verifica.Tccs.FirstAsync(t => t.Id == 1);
+        Assert.Equal(StatusTcc.AguardandoDefesa, tcc.Status);
+    }
+
+    [Fact]
+    public async Task DarAceiteFinal_SemEntregaFinal_RetornaBadRequest_ENaoEnfileira()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+
+        using (var ctx = factory.CriarContextoDireto())
+        {
+            ctx.Usuarios.AddRange(
+                NovoUsuario(idAluno, "Aluno", "aluno@teste.com", TipoUsuario.Aluno),
+                NovoUsuario(idOrientador, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+            ctx.Tccs.Add(new Tcc
+            {
+                Id = 1,
+                Titulo = "TCC de Teste",
+                Resumo = "Resumo",
+                AlunoId = idAluno,
+                OrientadorId = idOrientador,
+                Status = StatusTcc.EmAndamento,
+                DataCriacao = DateTime.UtcNow
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        var client = factory.CreateClientAutenticado(idOrientador, "Professor");
+
+        var response = await client.PostAsync("/api/orientador/tcc/1/aceite-final", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(fila.Mensagens);
+    }
+}

--- a/TccManager.Tests/Controllers/SanitizacaoXss_Integracao_Tests.cs
+++ b/TccManager.Tests/Controllers/SanitizacaoXss_Integracao_Tests.cs
@@ -1,0 +1,214 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Testes de integração da sanitização anti-XSS: exercitam o pipeline HTTP real
+/// (WebApplicationFactory) para confirmar que payloads com HTML são limpos antes
+/// de persistir, tanto no caminho application/json (SubmeterProposta) quanto no
+/// caminho multipart/form-data (RegistrarResultadoBanca).
+/// </summary>
+public class SanitizacaoXss_Integracao_Tests
+{
+    private const int ID_ALUNO = 10;
+    private const int ID_PROFESSOR = 20;
+    private const int ID_COORDENADOR = 1;
+
+    private const string PayloadScript = "<script>alert(1)</script>";
+
+    private async Task<TccApiFactory> PrepararCenarioComAluno()
+    {
+        var factory = new TccApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        context.Usuarios.Add(new Usuario
+        {
+            Id = ID_ALUNO,
+            Nome = "Aluno Teste",
+            Email = "aluno@teste.com",
+            SenhaHash = "x",
+            Tipo = TipoUsuario.Aluno,
+            Ativo = true
+        });
+        await context.SaveChangesAsync();
+
+        return factory;
+    }
+
+    [Fact]
+    public async Task SubmeterProposta_ComScriptNoTituloEResumo_PersisteSemTagScript()
+    {
+        // Arrange
+        var factory = await PrepararCenarioComAluno();
+        var client = factory.CreateClientAutenticado(ID_ALUNO, "Aluno");
+
+        var dto = new PropostaTccDto
+        {
+            Titulo = $"Meu TCC {PayloadScript}",
+            Resumo = $"Resumo do trabalho {PayloadScript} com conteúdo relevante."
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/tcc/proposta", dto);
+
+        // Assert — resposta bem-sucedida
+        response.EnsureSuccessStatusCode();
+
+        // Assert — valor persistido no banco não contém a tag <script>
+        using var context = factory.CriarContextoDireto();
+        var tcc = await context.Tccs.FirstAsync(t => t.AlunoId == ID_ALUNO);
+
+        Assert.DoesNotContain("<script", tcc.Titulo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", tcc.Titulo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", tcc.Titulo);
+        Assert.DoesNotContain(">", tcc.Titulo);
+
+        Assert.DoesNotContain("<script", tcc.Resumo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", tcc.Resumo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", tcc.Resumo);
+        Assert.DoesNotContain(">", tcc.Resumo);
+
+        // Assert — o texto legítimo em torno do payload é preservado
+        Assert.Contains("Meu TCC", tcc.Titulo);
+        Assert.Contains("Resumo do trabalho", tcc.Resumo);
+    }
+
+    [Fact]
+    public async Task SubmeterProposta_ComScript_RespostaRetornadaTambemSemTagScript()
+    {
+        // Arrange
+        var factory = await PrepararCenarioComAluno();
+        var client = factory.CreateClientAutenticado(ID_ALUNO, "Aluno");
+
+        var dto = new PropostaTccDto
+        {
+            Titulo = $"Título {PayloadScript}",
+            Resumo = $"Resumo {PayloadScript}"
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/tcc/proposta", dto);
+        response.EnsureSuccessStatusCode();
+
+        // Assert — o corpo devolvido ao cliente (que o front reexibe) já vem limpo
+        var corpo = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("<script", corpo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", corpo, StringComparison.OrdinalIgnoreCase);
+
+        var tccRetornado = await response.Content.ReadFromJsonAsync<Tcc>();
+        Assert.NotNull(tccRetornado);
+        Assert.DoesNotContain("<", tccRetornado!.Titulo);
+        Assert.DoesNotContain("<", tccRetornado.Resumo);
+    }
+
+    [Fact]
+    public async Task SubmeterProposta_ComImgOnError_RemoveAtributoDeEvento()
+    {
+        // Arrange
+        var factory = await PrepararCenarioComAluno();
+        var client = factory.CreateClientAutenticado(ID_ALUNO, "Aluno");
+
+        var dto = new PropostaTccDto
+        {
+            Titulo = "TCC <img src=x onerror=\"alert(1)\"> válido",
+            Resumo = "Resumo <b>importante</b> do trabalho."
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/tcc/proposta", dto);
+        response.EnsureSuccessStatusCode();
+
+        // Assert
+        using var context = factory.CriarContextoDireto();
+        var tcc = await context.Tccs.FirstAsync(t => t.AlunoId == ID_ALUNO);
+
+        Assert.DoesNotContain("onerror", tcc.Titulo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<img", tcc.Titulo, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<b>", tcc.Resumo, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("importante", tcc.Resumo);
+    }
+
+    // ── Caminho multipart/form-data ─────────────────────────────────────────
+
+    private async Task<(TccApiFactory factory, int bancaId, int tccId)> PrepararCenarioComBancaPendente()
+    {
+        var factory = new TccApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        context.Usuarios.Add(new Usuario { Id = ID_ALUNO, Nome = "Aluno Teste", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true });
+        context.Usuarios.Add(new Usuario { Id = ID_PROFESSOR, Nome = "Professor Teste", Email = "prof@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true });
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC de Teste",
+            Resumo = "Resumo de teste",
+            AlunoId = ID_ALUNO,
+            OrientadorId = ID_PROFESSOR,
+            Status = StatusTcc.AguardandoDefesa,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        context.Entregas.Add(new Entrega
+        {
+            TccId = tcc.Id,
+            Titulo = "Versão Final",
+            ArquivoCaminho = "/uploads/entregas/fake.pdf",
+            Tipo = TipoEntrega.Final,
+            DataEnvio = DateTime.UtcNow
+        });
+
+        var banca = new Banca
+        {
+            TccId = tcc.Id,
+            DataHora = DateTime.UtcNow.AddDays(1),
+            Local = "Sala de Teste"
+        };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        return (factory, banca.Id, tcc.Id);
+    }
+
+    [Fact]
+    public async Task RegistrarResultadoBanca_ComScriptNoMotivo_PersisteSemTagScript()
+    {
+        // Arrange
+        var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        var client = factory.CreateClientAutenticado(ID_COORDENADOR, "Coordenador");
+
+        var form = new MultipartFormDataContent();
+        form.Add(new StringContent("40.0"), "notaFinal"); // escala 0-100: reprova, exige motivo
+        form.Add(new StringContent($"Reprovado {PayloadScript} por metodologia."), "motivoReprovacao");
+
+        var pdfFake = new ByteArrayContent(new byte[] { 0x25, 0x50, 0x44, 0x46 }); // "%PDF"
+        pdfFake.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        form.Add(pdfFake, "arquivoAta", "ata-teste.pdf");
+
+        // Act
+        var response = await client.PostAsync(
+            $"/api/coordenador/banca/{bancaId}/registrar-resultado", form);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        using var context = factory.CriarContextoDireto();
+        var tcc = await context.Tccs.FirstAsync(t => t.Id == tccId);
+
+        Assert.Equal(StatusTcc.Reprovado, tcc.Status);
+        Assert.NotNull(tcc.MotivoRejeicao);
+        Assert.DoesNotContain("<script", tcc.MotivoRejeicao, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", tcc.MotivoRejeicao, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", tcc.MotivoRejeicao);
+        Assert.DoesNotContain(">", tcc.MotivoRejeicao);
+        Assert.Contains("Reprovado", tcc.MotivoRejeicao);
+        Assert.Contains("metodologia", tcc.MotivoRejeicao);
+    }
+}

--- a/TccManager.Tests/Logging/SensitiveDataMaskingPolicyTests.cs
+++ b/TccManager.Tests/Logging/SensitiveDataMaskingPolicyTests.cs
@@ -1,0 +1,218 @@
+using Serilog.Core;
+using Serilog.Events;
+using TccManager.Api.Logging;
+using Xunit;
+
+namespace TccManager.Tests.Logging;
+
+/// <summary>
+/// Testes unitários diretos de SensitiveDataMaskingPolicy (IDestructuringPolicy do Serilog),
+/// sem montar o pipeline completo. Verificam o mascaramento de campos sensíveis por nome,
+/// a passagem intacta de objetos sem esses campos e a exclusão de tipos dos namespaces
+/// System/Microsoft (conforme documentado na própria política).
+/// </summary>
+public class SensitiveDataMaskingPolicyTests
+{
+    private const string MaskedValue = "***REDACTED***";
+
+    /// <summary>
+    /// Fábrica mínima de LogEventPropertyValue: reflete o comportamento padrão do Serilog
+    /// (escalares viram ScalarValue) o bastante para exercitar a política isoladamente.
+    /// </summary>
+    private sealed class SimplePropertyValueFactory : ILogEventPropertyValueFactory
+    {
+        public LogEventPropertyValue CreatePropertyValue(object? value, bool destructureObjects)
+            => new ScalarValue(value);
+    }
+
+    private static readonly SimplePropertyValueFactory Factory = new();
+
+    private static Dictionary<string, LogEventPropertyValue> ComoDicionario(StructureValue structure)
+        => structure.Properties.ToDictionary(p => p.Name, p => p.Value);
+
+    private static string? ValorEscalar(LogEventPropertyValue value)
+        => (value as ScalarValue)?.Value?.ToString();
+
+    private sealed class UsuarioComSenha
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string Senha { get; set; } = string.Empty;
+    }
+
+    private sealed class UsuarioComSenhaHash
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string SenhaHash { get; set; } = string.Empty;
+    }
+
+    private sealed class CredencialComPassword
+    {
+        public string Login { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+
+    private sealed class RequisicaoComToken
+    {
+        public string Rota { get; set; } = string.Empty;
+        public string Token { get; set; } = string.Empty;
+    }
+
+    private sealed class RequisicaoComAuthorization
+    {
+        public string Rota { get; set; } = string.Empty;
+        public string Authorization { get; set; } = string.Empty;
+    }
+
+    private sealed class ObjetoSemCampoSensivel
+    {
+        public string Nome { get; set; } = string.Empty;
+        public int Idade { get; set; }
+    }
+
+    private sealed class SenhaCaixaAlta
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string SENHA { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoComSenha_MascaraApenasOValorSensivel()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new UsuarioComSenha { Nome = "Ariel", Senha = "segredo123" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["Senha"]));
+        Assert.Equal("Ariel", ValorEscalar(props["Nome"]));
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoComSenhaHash_MascaraOValor()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new UsuarioComSenhaHash { Nome = "Ariel", SenhaHash = "$2a$hash" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["SenhaHash"]));
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoComPassword_MascaraOValor()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new CredencialComPassword { Login = "user", Password = "p@ss" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["Password"]));
+        Assert.Equal("user", ValorEscalar(props["Login"]));
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoComToken_MascaraOValor()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new RequisicaoComToken { Rota = "/login", Token = "eyJhbGci" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["Token"]));
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoComAuthorization_MascaraOValor()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new RequisicaoComAuthorization { Rota = "/api", Authorization = "Bearer xyz" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["Authorization"]));
+    }
+
+    [Fact]
+    public void TryDestructure_NomeSensivelEmCaixaAlta_MascaraIgnorandoCase()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new SenhaCaixaAlta { Nome = "Ariel", SENHA = "segredo" };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.True(sucesso);
+        var props = ComoDicionario(Assert.IsType<StructureValue>(result));
+        Assert.Equal(MaskedValue, ValorEscalar(props["SENHA"]));
+    }
+
+    [Fact]
+    public void TryDestructure_ObjetoSemCampoSensivel_NaoEDestruturado()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new ObjetoSemCampoSensivel { Nome = "Ariel", Idade = 30 };
+
+        var sucesso = policy.TryDestructure(objeto, Factory, out var result);
+
+        Assert.False(sucesso);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDestructure_TipoDoNamespaceSystem_EIgnorado()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+
+        // String pertence a System; a política deve ignorar mesmo que o texto contenha "Senha".
+        var sucesso = policy.TryDestructure("Senha=123", Factory, out var result);
+
+        Assert.False(sucesso);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDestructure_TipoDoNamespaceMicrosoft_EIgnorado()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+
+        // Tipo do namespace Microsoft.* — ignorado por política, independente de propriedades.
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+
+        var sucesso = policy.TryDestructure(logger, Factory, out var result);
+
+        Assert.False(sucesso);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDestructure_ValorNulo_RetornaFalse()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+
+        var sucesso = policy.TryDestructure(null!, Factory, out var result);
+
+        Assert.False(sucesso);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TryDestructure_StructureValueUsaNomeDoTipoComoTypeTag()
+    {
+        var policy = new SensitiveDataMaskingPolicy();
+        var objeto = new UsuarioComSenha { Nome = "Ariel", Senha = "segredo123" };
+
+        policy.TryDestructure(objeto, Factory, out var result);
+
+        var structure = Assert.IsType<StructureValue>(result);
+        Assert.Equal(nameof(UsuarioComSenha), structure.TypeTag);
+    }
+}

--- a/TccManager.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/TccManager.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,0 +1,86 @@
+using System.Net.Http.Json;
+using TccManager.Shared.DTOs;
+using Xunit;
+
+namespace TccManager.Tests.Middleware;
+
+/// <summary>
+/// Testes de integração do <c>CorrelationIdMiddleware</c> (S1 / RF1.3 / RF1.4).
+/// O header usado é "X-Correlation-Id".
+/// </summary>
+public class CorrelationIdMiddlewareTests
+{
+    private const string HeaderName = "X-Correlation-Id";
+    private const string RotaLogin = "/api/auth/login";
+
+    private static LoginDto Credencial() =>
+        new() { Email = "qualquer@teste.com", Senha = "x" };
+
+    [Fact]
+    public async Task Resposta_SemHeaderNaRequisicao_DeveConterCorrelationIdGerado()
+    {
+        // Arrange
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(RotaLogin, Credencial());
+
+        // Assert
+        Assert.True(response.Headers.Contains(HeaderName),
+            $"A resposta deve conter o header {HeaderName}.");
+
+        var valor = response.Headers.GetValues(HeaderName).First();
+        Assert.False(string.IsNullOrWhiteSpace(valor));
+        Assert.True(Guid.TryParse(valor, out _),
+            $"Na ausência de header enviado pelo cliente, o {HeaderName} deve ser um GUID gerado. Valor: '{valor}'.");
+    }
+
+    [Fact]
+    public async Task Resposta_ComHeaderGuidValidoEnviadoPeloCliente_DevePropagarOMesmoValor()
+    {
+        // Arrange
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var correlationIdCliente = Guid.NewGuid().ToString();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, RotaLogin)
+        {
+            Content = JsonContent.Create(Credencial())
+        };
+        request.Headers.Add(HeaderName, correlationIdCliente);
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.True(response.Headers.Contains(HeaderName));
+        var valor = response.Headers.GetValues(HeaderName).First();
+        Assert.Equal(correlationIdCliente, valor);
+    }
+
+    [Fact]
+    public async Task Resposta_ComHeaderInvalidoEnviadoPeloCliente_DeveGerarNovoGuid()
+    {
+        // Arrange: um atacante não deve conseguir forjar um CorrelationId arbitrário (não-GUID) na trilha de auditoria.
+        var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var correlationIdForjado = "correlacao-fornecida-pelo-cliente-123";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, RotaLogin)
+        {
+            Content = JsonContent.Create(Credencial())
+        };
+        request.Headers.Add(HeaderName, correlationIdForjado);
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.True(response.Headers.Contains(HeaderName));
+        var valor = response.Headers.GetValues(HeaderName).First();
+        Assert.NotEqual(correlationIdForjado, valor);
+        Assert.True(Guid.TryParse(valor, out _),
+            $"Um valor de header não-GUID enviado pelo cliente deve ser substituído por um GUID gerado. Valor: '{valor}'.");
+    }
+}

--- a/TccManager.Tests/Services/Email/FakeEmailQueue.cs
+++ b/TccManager.Tests/Services/Email/FakeEmailQueue.cs
@@ -1,0 +1,39 @@
+using System.Runtime.CompilerServices;
+using TccManager.Api.Services.Email;
+
+namespace TccManager.Tests.Services.Email;
+
+/// <summary>
+/// Substituto de teste para IEmailQueue: captura em memória as mensagens enfileiradas
+/// sem depender do Channel/BackgroundService reais nem de SMTP. Permite inspecionar
+/// destinatários, assunto e corpo do EmailMessage produzido pela orquestração.
+/// </summary>
+public class FakeEmailQueue : IEmailQueue
+{
+    public List<EmailMessage> Mensagens { get; } = new();
+
+    /// <summary>Quando true, simula fila cheia (Enqueue retorna false e não captura).</summary>
+    public bool SimularFilaCheia { get; set; }
+
+    public bool Enqueue(EmailMessage mensagem)
+    {
+        if (SimularFilaCheia)
+        {
+            return false;
+        }
+
+        Mensagens.Add(mensagem);
+        return true;
+    }
+
+    /// <summary>
+    /// Não produz itens (o teste inspeciona <see cref="Mensagens"/> diretamente), mas aguarda
+    /// o cancelamento sem lançar exceção não tratada — assim o EmailBackgroundService real,
+    /// que consome esta fila via await foreach, não falha e não derruba o host de teste.
+    /// </summary>
+    public async IAsyncEnumerable<EmailMessage> DequeueAllAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        yield break;
+    }
+}

--- a/TccManager.Tests/Services/HtmlSanitizerServiceTests.cs
+++ b/TccManager.Tests/Services/HtmlSanitizerServiceTests.cs
@@ -1,0 +1,113 @@
+using TccManager.Api.Services;
+using Xunit;
+
+namespace TccManager.Tests.Services;
+
+public class HtmlSanitizerServiceTests
+{
+    private readonly HtmlSanitizerService _sut = new();
+
+    [Fact]
+    public void Sanitizar_ComTagScript_RemoveTagsDeixandoTextoInerte()
+    {
+        var resultado = _sut.Sanitizar("<script>alert(1)</script>");
+
+        // Política "remover todo HTML": o texto interno vira texto plano (RF2),
+        // mas nenhuma tag/marcação executável pode sobrar na saída.
+        Assert.NotNull(resultado);
+        Assert.DoesNotContain("<script", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", resultado);
+        Assert.DoesNotContain(">", resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComImgOnError_RemoveTagEAtributoDeEvento()
+    {
+        var resultado = _sut.Sanitizar("<img src=x onerror=\"alert(1)\">");
+
+        Assert.NotNull(resultado);
+        Assert.DoesNotContain("<img", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("onerror", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", resultado);
+        Assert.DoesNotContain(">", resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComTagFormatacao_RemoveTagPreservandoTexto()
+    {
+        var resultado = _sut.Sanitizar("<b>texto</b>");
+
+        // KeepChildNodes = true: a tag some, o texto interno permanece.
+        Assert.Equal("texto", resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComEntradaNula_RetornaNulo()
+    {
+        var resultado = _sut.Sanitizar(null);
+
+        Assert.Null(resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComEntradaVazia_RetornaStringVazia()
+    {
+        var resultado = _sut.Sanitizar(string.Empty);
+
+        Assert.Equal(string.Empty, resultado);
+    }
+
+    [Theory]
+    [InlineData("Texto simples sem nenhuma marcação")]
+    [InlineData("Sistema de Gestão de TCCs")]
+    [InlineData("Análise de desempenho: estudo de caso")]
+    public void Sanitizar_ComTextoSemHtml_RetornaExatamenteIgual(string entrada)
+    {
+        var resultado = _sut.Sanitizar(entrada);
+
+        Assert.Equal(entrada, resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComCaracteresEspeciais_MantemComoEntidadesHtmlSeguras()
+    {
+        // Caracteres especiais digitados literalmente pelo usuário (não são tags) ficam
+        // preservados como entidade HTML (ex.: "&lt;"), nunca decodificados de volta para
+        // "<"/">"/"&" literais — decodificar reabriria a possibilidade de reintroduzir
+        // HTML executável para entradas que contenham entidades (ver docs/seguranca/).
+        const string entrada = "Comparação entre 4 < 5 e 10 > 3 usando \"aspas\" & acentuação";
+
+        var resultado = _sut.Sanitizar(entrada);
+
+        Assert.Contains("&lt;", resultado);
+        Assert.Contains("&gt;", resultado);
+        Assert.Contains("&amp;", resultado);
+        Assert.DoesNotContain(" < 5", resultado);
+        Assert.DoesNotContain(" > 3", resultado);
+    }
+
+    [Fact]
+    public void Sanitizar_ComTagCodificadaComoEntidade_NaoReintroduzTagViva()
+    {
+        // Regressão do achado de segurança: um payload que chega já HTML-encoded
+        // (ex.: "&lt;script&gt;") não deve virar uma tag executável na saída.
+        var resultado = _sut.Sanitizar("&lt;script&gt;alert(1)&lt;/script&gt;");
+
+        Assert.NotNull(resultado);
+        Assert.DoesNotContain("<script", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("</script>", resultado, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sanitizar_ComJavascriptScheme_NaoDeixaHtmlExecutavel()
+    {
+        var resultado = _sut.Sanitizar("<a href=\"javascript:alert(1)\">clique</a>");
+
+        Assert.NotNull(resultado);
+        Assert.DoesNotContain("<a", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("href", resultado, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<", resultado);
+        Assert.DoesNotContain(">", resultado);
+    }
+}

--- a/TccManager.Tests/Services/Notifications/FileEmailTemplateRendererTests.cs
+++ b/TccManager.Tests/Services/Notifications/FileEmailTemplateRendererTests.cs
@@ -1,0 +1,115 @@
+using TccManager.Api.Services.Notifications;
+using Xunit;
+
+namespace TccManager.Tests.Services.Notifications;
+
+/// <summary>
+/// Testes unitários de FileEmailTemplateRenderer. Os templates são embedded resources
+/// na DLL de TccManager.Api (referenciada pelo projeto de teste), então o renderer real
+/// os carrega sem depender de path relativo. Aqui exercitamos a substituição de
+/// placeholders {{Chave}} contra os templates reais dos 7 eventos.
+/// </summary>
+public class FileEmailTemplateRendererTests
+{
+    private readonly FileEmailTemplateRenderer _renderer = new();
+
+    [Fact]
+    public void Render_SubstituiTodosOsPlaceholdersDoTemplate()
+    {
+        var valores = new Dictionary<string, string>
+        {
+            ["NomeAluno"] = "Maria Silva",
+            ["TituloTcc"] = "Análise de Redes Neurais",
+            ["NomeOrientador"] = "Prof. João Souza"
+        };
+
+        var corpo = _renderer.Render("proposta-aprovada", valores);
+
+        Assert.Contains("Maria Silva", corpo);
+        Assert.Contains("Análise de Redes Neurais", corpo);
+        Assert.Contains("Prof. João Souza", corpo);
+        // Nenhum dos placeholders resolvidos deve permanecer no corpo final.
+        Assert.DoesNotContain("{{NomeAluno}}", corpo);
+        Assert.DoesNotContain("{{TituloTcc}}", corpo);
+        Assert.DoesNotContain("{{NomeOrientador}}", corpo);
+    }
+
+    [Fact]
+    public void Render_SubstituiPlaceholderQueApareceMaisDeUmaVez()
+    {
+        // banca-agendada usa {{TituloTcc}} e {{NomeAluno}}; garantimos que a chave
+        // "TituloTcc" (referenciada uma vez no corpo) é substituída e o marcador some.
+        var valores = new Dictionary<string, string>
+        {
+            ["NomeAluno"] = "Ana",
+            ["TituloTcc"] = "Titulo X",
+            ["DataHora"] = "15/08/2026 14:30",
+            ["Local"] = "Sala 101",
+            ["ListaMembrosBanca"] = "<li>Fulano</li><li>Ciclano</li>"
+        };
+
+        var corpo = _renderer.Render("banca-agendada", valores);
+
+        Assert.DoesNotContain("{{TituloTcc}}", corpo);
+        Assert.DoesNotContain("{{ListaMembrosBanca}}", corpo);
+        Assert.Contains("15/08/2026 14:30", corpo);
+        Assert.Contains("Sala 101", corpo);
+        // O fragmento HTML intencional da lista deve entrar sem escape.
+        Assert.Contains("<li>Fulano</li><li>Ciclano</li>", corpo);
+    }
+
+    [Fact]
+    public void Render_PlaceholderNaoInformado_PermaneceLiteralNoCorpo()
+    {
+        // O renderer só troca as chaves presentes no dicionário; chaves ausentes
+        // ficam intactas. Documenta o contrato de substituição (não lança, não limpa).
+        var corpo = _renderer.Render("proposta-aprovada", new Dictionary<string, string>
+        {
+            ["NomeAluno"] = "Só o nome"
+        });
+
+        Assert.Contains("Só o nome", corpo);
+        Assert.Contains("{{TituloTcc}}", corpo);
+        Assert.Contains("{{NomeOrientador}}", corpo);
+    }
+
+    [Fact]
+    public void Render_ChaveExtraNaoPresenteNoTemplate_NaoAfetaResultado()
+    {
+        var corpo = _renderer.Render("aceite-final", new Dictionary<string, string>
+        {
+            ["NomeAluno"] = "Aluno",
+            ["TituloTcc"] = "Titulo",
+            ["ChaveInexistente"] = "ignorada"
+        });
+
+        Assert.DoesNotContain("ignorada", corpo);
+        Assert.DoesNotContain("{{NomeAluno}}", corpo);
+        Assert.DoesNotContain("{{TituloTcc}}", corpo);
+    }
+
+    [Theory]
+    [InlineData("proposta-aprovada")]
+    [InlineData("proposta-rejeitada")]
+    [InlineData("banca-agendada")]
+    [InlineData("feedback-registrado")]
+    [InlineData("aceite-final")]
+    [InlineData("resultado-aprovado")]
+    [InlineData("resultado-reprovado")]
+    public void Render_CadaUmDos7Templates_CarregaComSucesso(string chave)
+    {
+        var corpo = _renderer.Render(chave, new Dictionary<string, string>());
+
+        Assert.False(string.IsNullOrWhiteSpace(corpo));
+        Assert.Contains("<html", corpo);
+    }
+
+    [Fact]
+    public void Render_TemplateInexistente_LancaInvalidOperationException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _renderer.Render("template-que-nao-existe", new Dictionary<string, string>()));
+
+        Assert.Contains("template-que-nao-existe", ex.Message);
+    }
+}

--- a/TccManager.Tests/Services/Notifications/TccNotificationServiceTests.cs
+++ b/TccManager.Tests/Services/Notifications/TccNotificationServiceTests.cs
@@ -1,0 +1,321 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TccManager.Api.Data;
+using TccManager.Api.Services.Email;
+using TccManager.Api.Services.Notifications;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Services.Email;
+using Xunit;
+
+namespace TccManager.Tests.Services.Notifications;
+
+/// <summary>
+/// Testes unitários de TccNotificationService isolando a orquestração: AppDbContext
+/// InMemory dedicado, FileEmailTemplateRenderer real (templates embedded) e FakeEmailQueue
+/// para capturar o EmailMessage sem depender do BackgroundService/SMTP. Verificam
+/// destinatários e assunto de cada evento, a inclusão de coordenadores nos eventos
+/// corretos e o descarte defensivo de e-mails vazios/nulos.
+/// </summary>
+public class TccNotificationServiceTests
+{
+    private static AppDbContext CriarContexto()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static TccNotificationService CriarServico(AppDbContext context, FakeEmailQueue queue)
+        => new(
+            context,
+            new FileEmailTemplateRenderer(),
+            queue,
+            NullLogger<TccNotificationService>.Instance);
+
+    private static Usuario NovoUsuario(int id, string nome, string email, TipoUsuario tipo, bool ativo = true)
+        => new() { Id = id, Nome = nome, Email = email, SenhaHash = "x", Tipo = tipo, Ativo = ativo };
+
+    /// <summary>
+    /// Achata os destinatários da fila garantindo o novo contrato de privacidade: uma
+    /// EmailMessage por destinatário, cada uma com exatamente 1 e-mail no campo To:.
+    /// </summary>
+    private static List<string> DestinatariosDaFila(FakeEmailQueue queue)
+        => queue.Mensagens.Select(m => Assert.Single(m.Destinatarios)).ToList();
+
+    // ── PropostaAprovada ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarPropostaAprovadaAsync_EnfileiraParaOAluno()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.EmAndamento });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarPropostaAprovadaAsync(1);
+
+        var msg = Assert.Single(queue.Mensagens);
+        Assert.Equal("Proposta de TCC aprovada", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+    }
+
+    [Fact]
+    public async Task NotificarPropostaAprovadaAsync_TccInexistente_NaoEnfileiraNemLanca()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        await CriarServico(context, queue).NotificarPropostaAprovadaAsync(999);
+
+        Assert.Empty(queue.Mensagens);
+    }
+
+    // ── PropostaRejeitada ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarPropostaRejeitadaAsync_EnfileiraParaOAluno()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, MotivoRejeicao = "Escopo amplo", Status = StatusTcc.Pendente });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarPropostaRejeitadaAsync(1);
+
+        var msg = Assert.Single(queue.Mensagens);
+        Assert.Equal("Proposta de TCC rejeitada", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+    }
+
+    // ── BancaAgendada ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_IncluiAlunoOrientadorAvaliadoresInternosEExternos()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(21, "Avaliador Interno", "interno@teste.com", TipoUsuario.Professor));
+        context.MembrosExternos.Add(new MembroExterno { Id = 5, Nome = "Externo", Email = "externo@empresa.com", Instituicao = "Empresa" });
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1, ProfessorId = 21 });
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 2, BancaId = 1, MembroExternoId = 5 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        // Uma mensagem por destinatário (nunca todos no mesmo To:).
+        Assert.All(queue.Mensagens, m => Assert.Equal("Banca de TCC agendada", m.Assunto));
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(4, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.Contains("interno@teste.com", destinatarios);
+        Assert.Contains("externo@empresa.com", destinatarios);
+        // Nomes dos avaliadores devem aparecer na lista renderizada de cada mensagem.
+        Assert.All(queue.Mensagens, m => Assert.Contains("Avaliador Interno", m.CorpoHtml));
+        Assert.All(queue.Mensagens, m => Assert.Contains("Externo", m.CorpoHtml));
+    }
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_AvaliadorSemProfessorNemExterno_EIgnoradoSemDerrubarDemais()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        // Avaliador sem ProfessorId nem MembroExternoId resolvido (defesa em profundidade).
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(2, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+    }
+
+    // ── FeedbackRegistrado ────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarFeedbackRegistradoAsync_EnfileiraParaOAluno()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, Status = StatusTcc.EmAndamento });
+        context.Entregas.Add(new Entrega { Id = 7, TccId = 1, Titulo = "Entrega Parcial", ArquivoCaminho = "/x.pdf", Feedback = "Bom trabalho", Nota = 8.5m });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarFeedbackRegistradoAsync(7);
+
+        var msg = Assert.Single(queue.Mensagens);
+        Assert.Equal("Feedback registrado na sua entrega", msg.Assunto);
+        Assert.Equal(new[] { "aluno@teste.com" }, msg.Destinatarios);
+    }
+
+    // ── AceiteFinal (Aluno + Coordenadores ativos) ────────────────────
+
+    [Fact]
+    public async Task NotificarAceiteFinalAsync_IncluiAlunoETodosCoordenadoresAtivos()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(30, "Coord Um", "coord1@teste.com", TipoUsuario.Coordenador));
+        context.Usuarios.Add(NovoUsuario(31, "Coord Dois", "coord2@teste.com", TipoUsuario.Coordenador));
+        context.Usuarios.Add(NovoUsuario(32, "Coord Inativo", "coordinativo@teste.com", TipoUsuario.Coordenador, ativo: false));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, Status = StatusTcc.EmAndamento });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarAceiteFinalAsync(1);
+
+        Assert.All(queue.Mensagens, m => Assert.Equal("Aceite final concedido", m.Assunto));
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(3, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("coord1@teste.com", destinatarios);
+        Assert.Contains("coord2@teste.com", destinatarios);
+        Assert.DoesNotContain("coordinativo@teste.com", destinatarios);
+    }
+
+    // ── ResultadoBanca ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarResultadoBancaAsync_Aprovado_IncluiApenasAlunoEOrientador()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(30, "Coord", "coord@teste.com", TipoUsuario.Coordenador));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+        context.Banca.Add(new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(1), Local = "Sala 1", NotaFinal = 85m });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarResultadoBancaAsync(1, aprovado: true);
+
+        Assert.All(queue.Mensagens, m => Assert.Equal("Resultado final da banca: aprovado", m.Assunto));
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(2, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.DoesNotContain("coord@teste.com", destinatarios);
+    }
+
+    [Fact]
+    public async Task NotificarResultadoBancaAsync_Reprovado_IncluiAlunoOrientadorETodosCoordenadoresAtivos()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(30, "Coord Um", "coord1@teste.com", TipoUsuario.Coordenador));
+        context.Usuarios.Add(NovoUsuario(31, "Coord Inativo", "coordinativo@teste.com", TipoUsuario.Coordenador, ativo: false));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, MotivoRejeicao = "Nota insuficiente", Status = StatusTcc.AguardandoDefesa });
+        context.Banca.Add(new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(1), Local = "Sala 1", NotaFinal = 40m });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarResultadoBancaAsync(1, aprovado: false);
+
+        Assert.All(queue.Mensagens, m => Assert.Equal("Resultado final da banca: reprovado", m.Assunto));
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(3, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("orient@teste.com", destinatarios);
+        Assert.Contains("coord1@teste.com", destinatarios);
+        Assert.DoesNotContain("coordinativo@teste.com", destinatarios);
+        Assert.All(queue.Mensagens, m => Assert.Contains("Nota insuficiente", m.CorpoHtml));
+    }
+
+    // ── Filtragem defensiva de e-mail vazio/nulo ──────────────────────
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_DestinatarioComEmailVazio_EDescartadoSemLancar()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        // Orientador com e-mail vazio (cenário possível via PUT sem validação).
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(21, "Avaliador", "aval@teste.com", TipoUsuario.Professor));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1, ProfessorId = 21 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(2, destinatarios.Count);
+        Assert.Contains("aluno@teste.com", destinatarios);
+        Assert.Contains("aval@teste.com", destinatarios);
+        Assert.DoesNotContain("", destinatarios);
+    }
+
+    [Fact]
+    public async Task NotificarPropostaAprovadaAsync_UnicoDestinatarioComEmailVazio_NaoEnfileira()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "   ", TipoUsuario.Aluno));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, Status = StatusTcc.EmAndamento });
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarPropostaAprovadaAsync(1);
+
+        Assert.Empty(queue.Mensagens);
+    }
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_MesmoEmailEmMaisDeUmPapel_EnviaSemDuplicar()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        // Aluno e orientador com o mesmo e-mail: ColetarEmails aplica Distinct.
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "mesmo@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "mesmo@teste.com", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(21, "Avaliador", "aval@teste.com", TipoUsuario.Professor));
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1, ProfessorId = 21 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        // Distinct em ColetarEmails: 2 destinatários únicos, logo 2 mensagens,
+        // e "mesmo@teste.com" aparece em exatamente uma delas (não duplicado).
+        var destinatarios = DestinatariosDaFila(queue);
+        Assert.Equal(2, destinatarios.Count);
+        Assert.Single(destinatarios, d => d == "mesmo@teste.com");
+    }
+}

--- a/TccManager.Tests/TccApiFactory.cs
+++ b/TccManager.Tests/TccApiFactory.cs
@@ -15,6 +15,11 @@ public class TccApiFactory : WebApplicationFactory<Program>
     {
         builder.UseEnvironment("Development");
 
+        // Jwt:Key vem vazio no appsettings.json versionado; sem uma chave com tamanho
+        // suficiente (>= 256 bits para HMAC-SHA256) o AuthController.Login lança ao gerar
+        // o token e um login com credenciais válidas retornaria 500 em vez de 200.
+        builder.UseSetting("Jwt:Key", "chave-de-teste-super-secreta-para-jwt-1234567890");
+
         builder.ConfigureServices(services =>
         {
             // ── Remove TODOS os registros relacionados ao AppDbContext/SqlServer ──


### PR DESCRIPTION
## Summary
Implementação da Fase 1 (Segurança & Observabilidade) e S4 (Fase 3) da Matriz de Evolução, via esteira completa de agentes (requisitos → produto → arquitetura → dados → implementação → testes → segurança → QA), com documentação em `docs/` (mantida fora do controle de versão, conforme decisão do usuário).

- **fix: logs estruturados (Serilog) e rate limiting no login** — observabilidade com sink de arquivo, rotação diária, CorrelationId por requisição, mascaramento de dados sensíveis; proteção contra força bruta no login (5 tentativas/min por IP).
- **fix: sanitização anti-XSS nos campos de texto livre** — `ISanitizerService` (HtmlSanitizer) aplicado em Título, Resumo, Motivo de Rejeição, Ata e Feedback antes de persistir.
- **feat: notificações por e-mail (MailKit)** — 7 eventos com templates HTML dedicados, envio assíncrono via fila em memória (Channel + BackgroundService), uma mensagem por destinatário (evita expor e-mails entre avaliadores/coordenadores).
- **feat: refresh token e controle de sessão** — JWT reduzido de 1h para 15min, refresh token de 7 dias com rotação e sessão única por usuário, interceptor central de 401 no Client Blazor com renovação automática.

Cada correção passou por revisão de segurança dedicada (OWASP Top 10); achados corrigidos estão documentados nos commits individuais. Achados de menor severidade fora do escopo original foram registrados como backlog (JWT issuer/audience, auditoria de login, path traversal no upload de ata, etc.) para tratamento futuro.

## Test plan
- [x] `dotnet build` sem erros
- [x] `dotnet test` — 78/78 testes passando
- [x] Validar manualmente o fluxo de login/refresh/logout no Client
- [ ] Validar recebimento de e-mails com um SMTP sandbox local (smtp4dev/Papercut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)