### PR TITLE
feat: qualidade e confiabilidade (Q1-Q4)

### DIFF
--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
+using TccManager.Api.Extensions;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Notifications;
 using TccManager.Shared.DTOs;
@@ -42,7 +43,7 @@ public class CoordenadorController : ControllerBase
     }
 
     [HttpGet("professores")]
-    public async Task<IActionResult> GetProfessores()
+    public async Task<IActionResult> GetProfessores([FromQuery] PaginacaoQuery paginacao)
     {
         var professores = await _context.Usuarios
             .Where(u => u.Tipo == TipoUsuario.Professor && u.Ativo)
@@ -55,7 +56,7 @@ public class CoordenadorController : ControllerBase
                 CargaAtual = _context.Tccs.Count(t => t.OrientadorId == u.Id && (t.Status == StatusTcc.Aprovado || t.Status == StatusTcc.EmAndamento))
             })
             .OrderBy(p => p.Nome)
-            .ToListAsync();
+            .ToPagedResultAsync(paginacao);
 
         return Ok(professores);
     }
@@ -113,9 +114,19 @@ public class CoordenadorController : ControllerBase
 
     // --- CRUD MEMBROS EXTERNOS ---
     [HttpGet("membros-externos")]
-    public async Task<IActionResult> GetMembrosExternos()
+    public async Task<IActionResult> GetMembrosExternos([FromQuery] PaginacaoQuery paginacao)
     {
-        var membros = await _context.MembrosExternos.OrderBy(m => m.Nome).ToListAsync();
+        var membros = await _context.MembrosExternos
+            .OrderBy(m => m.Nome)
+            .Select(m => new MembroExternoDto
+            {
+                Id = m.Id,
+                Nome = m.Nome,
+                Email = m.Email,
+                Instituicao = m.Instituicao
+            })
+            .ToPagedResultAsync(paginacao);
+
         return Ok(membros);
     }
 

--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -5,6 +5,7 @@ using TccManager.Api.Data;
 using TccManager.Api.Extensions;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Notifications;
+using TccManager.Api.Services.Storage;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
@@ -19,13 +20,15 @@ public class CoordenadorController : ControllerBase
     private readonly AppDbContext _context;
     private readonly ISanitizerService _sanitizerService;
     private readonly ITccNotificationService _notificationService;
+    private readonly IStorageService _storageService;
     private const decimal notaMinimaAprovacao = 60.0m;
 
-    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService)
+    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService, IStorageService storageService)
     {
         _context = context;
         _sanitizerService = sanitizerService;
         _notificationService = notificationService;
+        _storageService = storageService;
     }
 
     [HttpGet("dashboard-stats")]
@@ -264,19 +267,14 @@ public class CoordenadorController : ControllerBase
         if (!aprovado && string.IsNullOrWhiteSpace(motivoReprovacao))
             return BadRequest($"Nota inferior a {notaMinimaAprovacao:0.0}. É obrigatório informar o motivo da reprovação.");
 
-        var uploadsFolder = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "uploads", "atas");
-        if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-
-        var uniqueFileName = Guid.NewGuid().ToString() + "_" + arquivoAta.FileName;
-        var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-        using (var stream = new FileStream(filePath, FileMode.Create))
+        string caminho;
+        using (var stream = arquivoAta.OpenReadStream())
         {
-            await arquivoAta.CopyToAsync(stream);
+            caminho = await _storageService.UploadAsync(stream, arquivoAta.FileName, CategoriaArquivo.Atas);
         }
 
         banca.NotaFinal = notaFinal;
-        banca.AtaCaminho = $"/uploads/atas/{uniqueFileName}";
+        banca.AtaCaminho = caminho;
 
         if (aprovado)
         {

--- a/TccManager.Api/Controllers/OrientadorController.cs
+++ b/TccManager.Api/Controllers/OrientadorController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using TccManager.Api.Data;
+using TccManager.Api.Extensions;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Notifications;
 using TccManager.Shared.DTOs;
@@ -28,7 +29,7 @@ public class OrientadorController : ControllerBase
     }
 
     [HttpGet("dashboard")]
-    public async Task<IActionResult> GetDaboard()
+    public async Task<IActionResult> GetDaboard([FromQuery] PaginacaoQuery paginacao)
     {
         var profIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (string.IsNullOrEmpty(profIdClaim) || !int.TryParse(profIdClaim, out int profId))
@@ -37,6 +38,7 @@ public class OrientadorController : ControllerBase
         var pendentes = await _context.Tccs
             .Include(t => t.Aluno)
             .Where(t => t.Status == StatusTcc.Pendente)
+            .OrderByDescending(t => t.DataCriacao)
             .Select(t => new TccResumoDto
             {
                 Id = t.Id,
@@ -45,7 +47,7 @@ public class OrientadorController : ControllerBase
                 NomeAluno = t.Aluno != null ? t.Aluno.Nome : "Desconecido",
                 DataCriacao = t.DataCriacao,
                 Status = t.Status
-            }).ToListAsync();
+            }).ToPagedResultAsync(paginacao);
 
         var ativos = await _context.Tccs
             .Include(t => t.Aluno)

--- a/TccManager.Api/Controllers/TccController.cs
+++ b/TccManager.Api/Controllers/TccController.cs
@@ -156,7 +156,7 @@ public class TccController : ControllerBase
         var entrega = new Entrega
         {
             TccId = tcc.Id,
-            Titulo = tituloEntrega,
+            Titulo = _sanitizerService.Sanitizar(tituloEntrega)!,
             ArquivoCaminho = $"/uploads/entregas/{fileName}",
             Tipo = tipo,
             DataEnvio = DateTime.UtcNow

--- a/TccManager.Api/Controllers/TccController.cs
+++ b/TccManager.Api/Controllers/TccController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
+using TccManager.Api.Extensions;
 using TccManager.Api.Services;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
@@ -96,7 +97,7 @@ public class TccController : ControllerBase
 
     [HttpGet("entregas")]
     [Authorize(Roles = "Aluno")]
-    public async Task<IActionResult> GetMinhasEntregas()
+    public async Task<IActionResult> GetMinhasEntregas([FromQuery] PaginacaoQuery paginacao)
     {
         var alunoIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (string.IsNullOrEmpty(alunoIdClaim) || !int.TryParse(alunoIdClaim, out int alunoId))
@@ -108,7 +109,7 @@ public class TccController : ControllerBase
         var entregas = await _context.Entregas
             .Where(e => e.TccId == tcc.Id)
             .OrderByDescending(e => e.DataEnvio)
-            .ToListAsync();
+            .ToPagedResultAsync(paginacao);
 
         return Ok(entregas);
     }

--- a/TccManager.Api/Controllers/TccController.cs
+++ b/TccManager.Api/Controllers/TccController.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
 using TccManager.Api.Extensions;
 using TccManager.Api.Services;
+using TccManager.Api.Services.Storage;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
@@ -17,14 +18,14 @@ namespace TccManager.Api.Controllers;
 public class TccController : ControllerBase
 {
     private readonly AppDbContext _context;
-    private readonly IWebHostEnvironment _environment;
     private readonly ISanitizerService _sanitizerService;
+    private readonly IStorageService _storageService;
 
-    public TccController(AppDbContext context, IWebHostEnvironment environment, ISanitizerService sanitizerService)
+    public TccController(AppDbContext context, ISanitizerService sanitizerService, IStorageService storageService)
     {
         _context = context;
-        _environment = environment;
         _sanitizerService = sanitizerService;
+        _storageService = storageService;
     }
 
     [HttpGet("meu-tcc")]
@@ -143,22 +144,17 @@ public class TccController : ControllerBase
         if (tipo == TipoEntrega.Final && tcc.OrientadorId == null)
             return BadRequest("Você não pode enviar a versão FINAL sem ter um Orientador definido (RN03).");
 
-        var uploadsFolder = Path.Combine(_environment.WebRootPath ?? Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"), "uploads", "entregas");
-        if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-
-        var fileName = $"{Guid.NewGuid()}_{Path.GetFileName(arquivo.FileName)}";
-        var filePath = Path.Combine(uploadsFolder, fileName);
-
-        using (var stream = new FileStream(filePath, FileMode.Create))
+        string caminho;
+        using (var stream = arquivo.OpenReadStream())
         {
-            await arquivo.CopyToAsync(stream);
+            caminho = await _storageService.UploadAsync(stream, arquivo.FileName, CategoriaArquivo.Entregas);
         }
 
         var entrega = new Entrega
         {
             TccId = tcc.Id,
             Titulo = _sanitizerService.Sanitizar(tituloEntrega)!,
-            ArquivoCaminho = $"/uploads/entregas/{fileName}",
+            ArquivoCaminho = caminho,
             Tipo = tipo,
             DataEnvio = DateTime.UtcNow
         };

--- a/TccManager.Api/Extensions/QueryablePagingExtensions.cs
+++ b/TccManager.Api/Extensions/QueryablePagingExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Extensions;
+
+public static class QueryablePagingExtensions
+{
+    public static async Task<PagedResult<T>> ToPagedResultAsync<T>(this IQueryable<T> query, PaginacaoQuery paginacao)
+    {
+        var pageSize = paginacao.PageSize <= 0 ? 1 : paginacao.PageSize;
+        var totalCount = await query.CountAsync();
+        var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
+
+        // Clampa a página ao intervalo real [1, totalPages] em vez de usar
+        // paginacao.Page diretamente: evita overflow de Int32 em (Page-1)*PageSize
+        // para um Page muito grande, e evita OFFSET profundo desnecessário no banco.
+        var page = totalPages > 0 ? Math.Min(Math.Max(paginacao.Page, 1), totalPages) : 1;
+        var skip = (page - 1) * pageSize;
+
+        var items = await query
+            .Skip(skip)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return new PagedResult<T>
+        {
+            Items = items,
+            TotalCount = totalCount,
+            TotalPages = totalPages,
+            CurrentPage = page,
+            PageSize = pageSize
+        };
+    }
+}

--- a/TccManager.Api/Filters/FluentValidationActionFilter.cs
+++ b/TccManager.Api/Filters/FluentValidationActionFilter.cs
@@ -1,0 +1,55 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+
+namespace TccManager.Api.Filters;
+
+/// <summary>
+/// Executa a validação FluentValidation (2ª camada) para os argumentos da action que
+/// possuírem um IValidator{T} registrado no container. Em caso de falha, os erros são
+/// copiados para o ModelState e a resposta é gerada pela mesma fábrica configurada em
+/// ApiBehaviorOptions.InvalidModelStateResponseFactory, garantindo o mesmo formato
+/// (ValidationProblemDetails) já usado pelas DataAnnotations do [ApiController].
+/// </summary>
+public class FluentValidationActionFilter : IAsyncActionFilter
+{
+    private readonly IOptions<ApiBehaviorOptions> _apiBehaviorOptions;
+
+    public FluentValidationActionFilter(IOptions<ApiBehaviorOptions> apiBehaviorOptions)
+    {
+        _apiBehaviorOptions = apiBehaviorOptions;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        foreach (var argument in context.ActionArguments.Values)
+        {
+            if (argument is null)
+                continue;
+
+            var validatorType = typeof(IValidator<>).MakeGenericType(argument.GetType());
+            if (context.HttpContext.RequestServices.GetService(validatorType) is not IValidator validator)
+                continue;
+
+            var validationContext = new ValidationContext<object>(argument);
+            var result = await validator.ValidateAsync(validationContext);
+
+            if (!result.IsValid)
+            {
+                foreach (var error in result.Errors)
+                {
+                    context.ModelState.AddModelError(error.PropertyName, error.ErrorMessage);
+                }
+            }
+        }
+
+        if (!context.ModelState.IsValid)
+        {
+            context.Result = _apiBehaviorOptions.Value.InvalidModelStateResponseFactory(context);
+            return;
+        }
+
+        await next();
+    }
+}

--- a/TccManager.Api/ModelBinding/PaginacaoQueryModelBinder.cs
+++ b/TccManager.Api/ModelBinding/PaginacaoQueryModelBinder.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.ModelBinding;
+
+public class PaginacaoQueryModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext == null)
+            throw new ArgumentNullException(nameof(bindingContext));
+
+        var pageResult = bindingContext.ValueProvider.GetValue("page");
+        var pageSizeResult = bindingContext.ValueProvider.GetValue("pageSize");
+
+        var page = NormalizarPage(pageResult.FirstValue);
+        var pageSize = NormalizarPageSize(pageSizeResult.FirstValue);
+
+        var model = new PaginacaoQuery
+        {
+            Page = page,
+            PageSize = pageSize
+        };
+
+        bindingContext.Result = ModelBindingResult.Success(model);
+        return Task.CompletedTask;
+    }
+
+    private static int NormalizarPage(string? valorBruto)
+    {
+        if (!int.TryParse(valorBruto, out var page) || page < 1)
+            return PaginacaoQuery.DefaultPage;
+
+        return page;
+    }
+
+    private static int NormalizarPageSize(string? valorBruto)
+    {
+        if (!int.TryParse(valorBruto, out var pageSize) || pageSize < 1)
+            return PaginacaoQuery.DefaultPageSize;
+
+        if (pageSize > PaginacaoQuery.MaxPageSize)
+            return PaginacaoQuery.MaxPageSize;
+
+        return pageSize;
+    }
+}

--- a/TccManager.Api/ModelBinding/PaginacaoQueryModelBinderProvider.cs
+++ b/TccManager.Api/ModelBinding/PaginacaoQueryModelBinderProvider.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.ModelBinding;
+
+public class PaginacaoQueryModelBinderProvider : IModelBinderProvider
+{
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        if (context.Metadata.ModelType == typeof(PaginacaoQuery))
+            return new PaginacaoQueryModelBinder();
+
+        return null;
+    }
+}

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -2,9 +2,11 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
+using FluentValidation;
 using TccManager.Api.Binders;
 using TccManager.Api.Configuration;
 using TccManager.Api.Data;
+using TccManager.Api.Filters;
 using TccManager.Api.Middleware;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Auth;
@@ -22,6 +24,7 @@ try
     builder.Services.AddControllers(options =>
     {
         options.ModelBinderProviders.Insert(0, new InvariantDecimalModelBinderProvider());
+        options.Filters.Add<FluentValidationActionFilter>();
     })
         .AddJsonOptions(options =>
         {
@@ -30,6 +33,9 @@ try
 
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
+
+    builder.Services.AddSingleton(TimeProvider.System);
+    builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
 
     // Configuração do Entity Framework (Banco de Dados)
     var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -11,6 +11,7 @@ using TccManager.Api.Middleware;
 using TccManager.Api.ModelBinding;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Auth;
+using TccManager.Api.Services.Storage;
 using System.Text;
 using Serilog;
 
@@ -78,6 +79,7 @@ try
     builder.Services.ConfigureRateLimiting(builder.Configuration);
 
     builder.Services.AddSingleton<ISanitizerService, HtmlSanitizerService>();
+    builder.Services.AddSingleton<IStorageService, LocalStorageService>();
 
     builder.Services.AddScoped<ITokenService, TokenService>();
     builder.Services.AddScoped<IAuthTokenService, AuthTokenService>();

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -8,6 +8,7 @@ using TccManager.Api.Configuration;
 using TccManager.Api.Data;
 using TccManager.Api.Filters;
 using TccManager.Api.Middleware;
+using TccManager.Api.ModelBinding;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Auth;
 using System.Text;
@@ -24,6 +25,7 @@ try
     builder.Services.AddControllers(options =>
     {
         options.ModelBinderProviders.Insert(0, new InvariantDecimalModelBinderProvider());
+        options.ModelBinderProviders.Insert(0, new PaginacaoQueryModelBinderProvider());
         options.Filters.Add<FluentValidationActionFilter>();
     })
         .AddJsonOptions(options =>

--- a/TccManager.Api/Services/Storage/CategoriaArquivo.cs
+++ b/TccManager.Api/Services/Storage/CategoriaArquivo.cs
@@ -1,0 +1,7 @@
+namespace TccManager.Api.Services.Storage;
+
+public enum CategoriaArquivo
+{
+    Entregas,
+    Atas
+}

--- a/TccManager.Api/Services/Storage/IStorageService.cs
+++ b/TccManager.Api/Services/Storage/IStorageService.cs
@@ -1,0 +1,18 @@
+namespace TccManager.Api.Services.Storage;
+
+public interface IStorageService
+{
+    // Grava o conteúdo e devolve o caminho relativo já no formato persistido/servido hoje:
+    //   "/uploads/entregas/{guid}_{nomeSaneado}"  ou  "/uploads/atas/{guid}_{nomeSaneado}"
+    Task<string> UploadAsync(
+        Stream conteudo,
+        string nomeArquivoOriginal,
+        CategoriaArquivo categoria,
+        CancellationToken cancellationToken = default);
+
+    // Traduz o caminho relativo persistido em uma URL de download.
+    Task<string> GetUrlAsync(string caminhoRelativo);
+
+    // Remove o arquivo físico correspondente ao caminho relativo persistido.
+    Task DeleteAsync(string caminhoRelativo, CancellationToken cancellationToken = default);
+}

--- a/TccManager.Api/Services/Storage/LocalStorageService.cs
+++ b/TccManager.Api/Services/Storage/LocalStorageService.cs
@@ -1,0 +1,70 @@
+namespace TccManager.Api.Services.Storage;
+
+public class LocalStorageService : IStorageService
+{
+    private readonly IWebHostEnvironment _env;
+
+    public LocalStorageService(IWebHostEnvironment env)
+    {
+        _env = env;
+    }
+
+    public async Task<string> UploadAsync(
+        Stream conteudo,
+        string nomeArquivoOriginal,
+        CategoriaArquivo categoria,
+        CancellationToken cancellationToken = default)
+    {
+        var pastaCategoria = ObterNomePasta(categoria);
+        var uploadsFolder = Path.Combine(ObterWebRootBase(), "uploads", pastaCategoria);
+
+        if (!Directory.Exists(uploadsFolder))
+            Directory.CreateDirectory(uploadsFolder);
+
+        var nomeSaneado = Path.GetFileName(nomeArquivoOriginal);
+        var fileName = $"{Guid.NewGuid()}_{nomeSaneado}";
+        var filePath = Path.Combine(uploadsFolder, fileName);
+
+        await using (var stream = new FileStream(filePath, FileMode.Create))
+        {
+            await conteudo.CopyToAsync(stream, cancellationToken);
+        }
+
+        return $"/uploads/{pastaCategoria}/{fileName}";
+    }
+
+    public Task<string> GetUrlAsync(string caminhoRelativo)
+    {
+        return Task.FromResult(caminhoRelativo);
+    }
+
+    public Task DeleteAsync(string caminhoRelativo, CancellationToken cancellationToken = default)
+    {
+        var webRootBase = Path.GetFullPath(ObterWebRootBase());
+        var uploadsDir = Path.Combine(webRootBase, "uploads");
+        var caminhoRelativoNormalizado = caminhoRelativo.TrimStart('/', '\\');
+        var caminhoCompleto = Path.GetFullPath(Path.Combine(webRootBase, caminhoRelativoNormalizado));
+
+        // Confina a exclusão à pasta de uploads: rejeita qualquer ".." que escape
+        // dela, mesmo que caminhoRelativo venha de uma fonte não confiável no futuro.
+        if (!caminhoCompleto.StartsWith(uploadsDir + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException("Caminho fora do diretório de uploads.");
+
+        if (File.Exists(caminhoCompleto))
+            File.Delete(caminhoCompleto);
+
+        return Task.CompletedTask;
+    }
+
+    private string ObterWebRootBase()
+    {
+        return _env.WebRootPath ?? Path.Combine(Directory.GetCurrentDirectory(), "wwwroot");
+    }
+
+    private static string ObterNomePasta(CategoriaArquivo categoria) => categoria switch
+    {
+        CategoriaArquivo.Entregas => "entregas",
+        CategoriaArquivo.Atas => "atas",
+        _ => throw new ArgumentOutOfRangeException(nameof(categoria), categoria, "Categoria de arquivo desconhecida.")
+    };
+}

--- a/TccManager.Api/TccManager.Api.csproj
+++ b/TccManager.Api/TccManager.Api.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />

--- a/TccManager.Api/Validators/AcompanhamentoDtoValidator.cs
+++ b/TccManager.Api/Validators/AcompanhamentoDtoValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Validators;
+
+public class AcompanhamentoDtoValidator : AbstractValidator<AcompanhamentoDto>
+{
+    public AcompanhamentoDtoValidator()
+    {
+    }
+}

--- a/TccManager.Api/Validators/AgendarBancaDtoValidator.cs
+++ b/TccManager.Api/Validators/AgendarBancaDtoValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using TccManager.Api.Services;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Validators;
+
+public class AgendarBancaDtoValidator : AbstractValidator<AgendarBancaDto>
+{
+    public AgendarBancaDtoValidator(TimeProvider timeProvider)
+    {
+        RuleFor(dto => dto.DataHora)
+            .Must(dataHora => BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dataHora) > timeProvider.GetUtcNow().UtcDateTime)
+            .WithMessage("A data e hora da banca devem ser futuras.");
+    }
+}

--- a/TccManager.Api/Validators/CapacidadeProfessorDtoValidator.cs
+++ b/TccManager.Api/Validators/CapacidadeProfessorDtoValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Validators;
+
+public class CapacidadeProfessorDtoValidator : AbstractValidator<CapacidadeProfessorDto>
+{
+    public CapacidadeProfessorDtoValidator()
+    {
+        RuleFor(dto => dto.LimiteOrientandos)
+            .InclusiveBetween(1, 20)
+            .WithMessage("O limite de orientandos deve estar entre 1 e 20.");
+    }
+}

--- a/TccManager.Api/Validators/FeedbackDtoValidator.cs
+++ b/TccManager.Api/Validators/FeedbackDtoValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Validators;
+
+public class FeedbackDtoValidator : AbstractValidator<FeedbackDto>
+{
+    public FeedbackDtoValidator()
+    {
+        RuleFor(dto => dto.Nota)
+            .InclusiveBetween(0, 10)
+            .When(dto => dto.Nota.HasValue)
+            .WithMessage("A nota deve estar entre 0 e 10.");
+    }
+}

--- a/TccManager.Api/Validators/PropostaTccDtoValidator.cs
+++ b/TccManager.Api/Validators/PropostaTccDtoValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+using TccManager.Shared.DTOs;
+
+namespace TccManager.Api.Validators;
+
+public class PropostaTccDtoValidator : AbstractValidator<PropostaTccDto>
+{
+    public PropostaTccDtoValidator()
+    {
+    }
+}

--- a/TccManager.Client/Pages/Aluno/MeuTcc.razor
+++ b/TccManager.Client/Pages/Aluno/MeuTcc.razor
@@ -407,7 +407,8 @@
 
     private async Task CarregarEntregas()
     {
-        entregasFeitas = await Http.GetFromJsonAsync<List<Entrega>>("api/tcc/entregas");
+        var entregasPaginado = await Http.GetFromJsonAsync<PagedResult<Entrega>>($"api/tcc/entregas?pageSize={PaginacaoQuery.MaxPageSize}");
+        entregasFeitas = entregasPaginado?.Items ?? new();
 
         meusAcompanhamentos = await Http.GetFromJsonAsync<List<Acompanhamento>>("api/tcc/acompanhamentos");
 

--- a/TccManager.Client/Pages/Coordenador/AgendamentoBanca.razor
+++ b/TccManager.Client/Pages/Coordenador/AgendamentoBanca.razor
@@ -120,8 +120,12 @@
         try
         {
             tccsProntos = await Http.GetFromJsonAsync<List<TccAguardandoBancaDto>>("api/coordenador/aguardando-banca");
-            todosProfessores = await Http.GetFromJsonAsync<List<ProfessorResumoDto>>("api/coordenador/professores");
-            todosExternos = await Http.GetFromJsonAsync<List<MembroExternoDto>>("api/coordenador/membros-externos");
+
+            var professoresPaginado = await Http.GetFromJsonAsync<PagedResult<ProfessorResumoDto>>($"api/coordenador/professores?pageSize={PaginacaoQuery.MaxPageSize}");
+            todosProfessores = professoresPaginado?.Items ?? new();
+
+            var externosPaginado = await Http.GetFromJsonAsync<PagedResult<MembroExternoDto>>($"api/coordenador/membros-externos?pageSize={PaginacaoQuery.MaxPageSize}");
+            todosExternos = externosPaginado?.Items ?? new();
         }
         finally { carregando = false; }
     }

--- a/TccManager.Client/Pages/Coordenador/Dashboard.razor
+++ b/TccManager.Client/Pages/Coordenador/Dashboard.razor
@@ -160,7 +160,8 @@
         {
             stats = await Http.GetFromJsonAsync<DashboardCoordenadorDto>("api/coordenador/dashboard-stats");
             pendentes = await Http.GetFromJsonAsync<List<TccResumoDto>>("api/coordenador/propostas-pendentes");
-            professores = await Http.GetFromJsonAsync<List<ProfessorResumoDto>>("api/coordenador/professores");
+            var professoresPaginado = await Http.GetFromJsonAsync<PagedResult<ProfessorResumoDto>>($"api/coordenador/professores?pageSize={PaginacaoQuery.MaxPageSize}");
+            professores = professoresPaginado?.Items;
         }
         catch { await JSRuntime.InvokeVoidAsync("alert", "Erro ao carregar dados do painel."); }
         finally { carregando = false; }

--- a/TccManager.Client/Pages/Coordenador/GestaoProfessores.razor
+++ b/TccManager.Client/Pages/Coordenador/GestaoProfessores.razor
@@ -36,7 +36,7 @@
             <div class="card shadow-sm">
                 <div class="card-body">
                     <p class="text-muted mb-4">Gerencie a carga de orientandos de cada professor. Professores marcados como indisponíveis não aparecerão na lista de designação.</p>
-                    
+
                     <div class="table-responsive">
                         <table class="table table-hover align-middle">
                             <thead class="table-light">
@@ -49,7 +49,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var prof in professores)
+                                @foreach (var prof in professores.Items)
                                 {
                                     <tr>
                                         <td class="fw-bold">@prof.Nome</td>
@@ -76,6 +76,8 @@
                             </tbody>
                         </table>
                     </div>
+
+                    <Paginacao PaginaAtual="professores.CurrentPage" TotalPaginas="professores.TotalPages" OnMudarPagina="MudarPaginaProfessores" />
                 </div>
             </div>
         }
@@ -115,14 +117,14 @@
                 <div class="col-md-8">
                     <div class="card shadow-sm">
                         <div class="card-body">
-                            @if (!externos.Any())
+                            @if (!externos.Items.Any())
                             {
                                 <div class="alert alert-light text-center mb-0">Nenhum avaliador externo cadastrado.</div>
                             }
                             else
                             {
                                 <ul class="list-group list-group-flush">
-                                    @foreach (var membro in externos)
+                                    @foreach (var membro in externos.Items)
                                     {
                                         <li class="list-group-item d-flex justify-content-between align-items-center">
                                             <div>
@@ -143,6 +145,8 @@
                                         </li>
                                     }
                                 </ul>
+
+                                <Paginacao PaginaAtual="externos.CurrentPage" TotalPaginas="externos.TotalPages" OnMudarPagina="MudarPaginaExternos" />
                             }
                         </div>
                     </div>
@@ -194,11 +198,14 @@
     private string abaAtiva = "internos";
     private bool carregando = true;
 
-    private List<ProfessorResumoDto>? professores;
-    private List<MembroExterno>? externos;
-    
+    private PagedResult<ProfessorResumoDto>? professores;
+    private PagedResult<MembroExternoDto>? externos;
+
+    private int paginaProfessores = 1;
+    private int paginaExternos = 1;
+
     private MembroExterno novoExterno = new();
-    
+
     // Variáveis para o Modal
     private bool exibirModalEdicao = false;
     private MembroExternoDto membroParaEdicao = new();
@@ -213,11 +220,23 @@
         carregando = true;
         try
         {
-            professores = await Http.GetFromJsonAsync<List<ProfessorResumoDto>>("api/coordenador/professores");
-            externos = await Http.GetFromJsonAsync<List<MembroExterno>>("api/coordenador/membros-externos");
+            professores = await Http.GetFromJsonAsync<PagedResult<ProfessorResumoDto>>($"api/coordenador/professores?page={paginaProfessores}");
+            externos = await Http.GetFromJsonAsync<PagedResult<MembroExternoDto>>($"api/coordenador/membros-externos?page={paginaExternos}");
         }
         catch { await JSRuntime.InvokeVoidAsync("alert", "Erro ao carregar os dados."); }
         finally { carregando = false; }
+    }
+
+    private async Task MudarPaginaProfessores(int novaPagina)
+    {
+        paginaProfessores = novaPagina;
+        professores = await Http.GetFromJsonAsync<PagedResult<ProfessorResumoDto>>($"api/coordenador/professores?page={paginaProfessores}");
+    }
+
+    private async Task MudarPaginaExternos(int novaPagina)
+    {
+        paginaExternos = novaPagina;
+        externos = await Http.GetFromJsonAsync<PagedResult<MembroExternoDto>>($"api/coordenador/membros-externos?page={paginaExternos}");
     }
 
     private async Task SalvarCapacidade(ProfessorResumoDto prof)
@@ -257,7 +276,7 @@
 
     // --- LÓGICA DO MODAL DE EDIÇÃO ---
 
-    private void AbrirModalEdicao(MembroExterno membro)
+    private void AbrirModalEdicao(MembroExternoDto membro)
     {
         membroParaEdicao = new MembroExternoDto
         {

--- a/TccManager.Client/Pages/Professor/Dashboard.razor
+++ b/TccManager.Client/Pages/Professor/Dashboard.razor
@@ -24,17 +24,17 @@
                 <div class="card shadow-sm border-warning h-100">
                     <div class="card-header bg-warning text-dark fw-bold d-flex justify-content-between align-items-center">
                         <span><i class="bi bi-inbox-fill me-2"></i> Propostas Pendentes</span>
-                        <span class="badge bg-dark rounded-pill">@dashboard.PropostasPendentes.Count</span>
+                        <span class="badge bg-dark rounded-pill">@dashboard.PropostasPendentes.TotalCount</span>
                     </div>
                     <div class="card-body bg-light">
-                        @if (!dashboard.PropostasPendentes.Any())
+                        @if (!dashboard.PropostasPendentes.Items.Any())
                         {
                             <p class="text-muted text-center mt-3">Não há propostas aguardando aprovação.</p>
                         }
                         else
                         {
                             <div class="accordion" id="accordionPendentes">
-                                @foreach (var tcc in dashboard.PropostasPendentes)
+                                @foreach (var tcc in dashboard.PropostasPendentes.Items)
                                 {
                                     <div class="accordion-item mb-2 border">
                                         <h2 class="accordion-header" id="heading_@tcc.Id">
@@ -60,6 +60,8 @@
                                     </div>
                                 }
                             </div>
+
+                            <Paginacao PaginaAtual="dashboard.PropostasPendentes.CurrentPage" TotalPaginas="dashboard.PropostasPendentes.TotalPages" OnMudarPagina="MudarPaginaPropostasPendentes" />
                         }
                     </div>
                 </div>
@@ -105,6 +107,7 @@
 @code {
     private bool carregando = true;
     private DashboardOrientadorDto? dashboard;
+    private int paginaPropostasPendentes = 1;
 
     protected override async Task OnInitializedAsync()
     {
@@ -116,10 +119,16 @@
         carregando = true;
         try
         {
-            dashboard = await Http.GetFromJsonAsync<DashboardOrientadorDto>("api/orientador/dashboard");
+            dashboard = await Http.GetFromJsonAsync<DashboardOrientadorDto>($"api/orientador/dashboard?page={paginaPropostasPendentes}");
         }
         catch { await JSRuntime.InvokeVoidAsync("alert", "Erro ao carregar o dashboard."); }
         finally { carregando = false; }
+    }
+
+    private async Task MudarPaginaPropostasPendentes(int novaPagina)
+    {
+        paginaPropostasPendentes = novaPagina;
+        await CarregarDashboard();
     }
 
     // RF011: Aprovar Proposta

--- a/TccManager.Client/Shared/Components/Paginacao.razor
+++ b/TccManager.Client/Shared/Components/Paginacao.razor
@@ -1,0 +1,30 @@
+<div class="d-flex justify-content-between align-items-center mt-3">
+    <button class="btn btn-outline-secondary btn-sm" disabled="@(PaginaAtual <= 1)" @onclick="() => MudarPagina(PaginaAtual - 1)">
+        <i class="bi bi-arrow-left me-1"></i> Anterior
+    </button>
+
+    <span class="text-muted small">Página @PaginaAtual de @(TotalPaginas == 0 ? 1 : TotalPaginas)</span>
+
+    <button class="btn btn-outline-secondary btn-sm" disabled="@(PaginaAtual >= TotalPaginas)" @onclick="() => MudarPagina(PaginaAtual + 1)">
+        Próxima <i class="bi bi-arrow-right ms-1"></i>
+    </button>
+</div>
+
+@code {
+    [Parameter]
+    public int PaginaAtual { get; set; }
+
+    [Parameter]
+    public int TotalPaginas { get; set; }
+
+    [Parameter]
+    public EventCallback<int> OnMudarPagina { get; set; }
+
+    private async Task MudarPagina(int novaPagina)
+    {
+        if (novaPagina < 1 || novaPagina > TotalPaginas || novaPagina == PaginaAtual)
+            return;
+
+        await OnMudarPagina.InvokeAsync(novaPagina);
+    }
+}

--- a/TccManager.Client/_Imports.razor
+++ b/TccManager.Client/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using TccManager.Client
 @using TccManager.Client.Layout
+@using TccManager.Client.Shared.Components

--- a/TccManager.Shared/DTOs/OrientadorDtos.cs
+++ b/TccManager.Shared/DTOs/OrientadorDtos.cs
@@ -5,7 +5,7 @@ namespace TccManager.Shared.DTOs;
 
 public class DashboardOrientadorDto
 {
-    public List<TccResumoDto> PropostasPendentes { get; set; } = new();
+    public PagedResult<TccResumoDto> PropostasPendentes { get; set; } = new();
     public List<TccResumoDto> OrientandosAtivos { get; set; } = new();
 }
 

--- a/TccManager.Shared/DTOs/PagedResult.cs
+++ b/TccManager.Shared/DTOs/PagedResult.cs
@@ -1,0 +1,10 @@
+namespace TccManager.Shared.DTOs;
+
+public class PagedResult<T>
+{
+    public List<T> Items { get; set; } = new();
+    public int TotalCount { get; set; }
+    public int TotalPages { get; set; }
+    public int CurrentPage { get; set; }
+    public int PageSize { get; set; }
+}

--- a/TccManager.Shared/DTOs/PaginacaoQuery.cs
+++ b/TccManager.Shared/DTOs/PaginacaoQuery.cs
@@ -1,0 +1,11 @@
+namespace TccManager.Shared.DTOs;
+
+public class PaginacaoQuery
+{
+    public const int DefaultPage = 1;
+    public const int DefaultPageSize = 20;
+    public const int MaxPageSize = 100;
+
+    public int Page { get; set; } = DefaultPage;
+    public int PageSize { get; set; } = DefaultPageSize;
+}

--- a/TccManager.Tests/Controllers/CoordenadorController_RegistrarResultadoBanca_Tests.cs
+++ b/TccManager.Tests/Controllers/CoordenadorController_RegistrarResultadoBanca_Tests.cs
@@ -1,7 +1,8 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
 using Xunit;
 
 namespace TccManager.Tests.Controllers;
@@ -12,9 +13,9 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     private const int idAluno = 10;
     private const int idProfessor = 20;
 
-    private async Task<(TccApiFactory factory, int bancaId, int tccId)> PrepararCenarioComBancaPendente()
+    private async Task<(WebRootIsolatedApiFactory factory, int bancaId, int tccId)> PrepararCenarioComBancaPendente()
     {
-        var factory = new TccApiFactory();
+        var factory = new WebRootIsolatedApiFactory();
         using var context = factory.CriarContextoDireto();
 
         var aluno = new Usuario { Id = idAluno, Nome = "Aluno Teste", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
@@ -79,6 +80,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     {
         // Arrange
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act
@@ -94,6 +96,11 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
 
         Assert.Equal(StatusTcc.Finalizado, tcc.Status);
         Assert.Null(tcc.MotivoRejeicao);
+
+        // O arquivo físico da ata deve ter sido gravado no web root temporário isolado,
+        // e não no wwwroot real do projeto.
+        Assert.True(Directory.Exists(factory.PastaAtas));
+        Assert.Single(Directory.GetFiles(factory.PastaAtas));
     }
 
     [Fact]
@@ -101,6 +108,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     {
         // Arrange
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
         const string motivoEsperado = "Trabalho não atendeu aos requisitos metodológicos mínimos.";
 
@@ -125,6 +133,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
         // Arrange — valida a regra de negócio no backend, independente do
         // botão desabilitado no frontend (defesa em profundidade)
         var (factory, bancaId, _) = await PrepararCenarioComBancaPendente();
+        using var _fd = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act
@@ -141,6 +150,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     {
         // Arrange — caso de fronteira: valida o operador ">=" usado na correção
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act
@@ -164,6 +174,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
         // para distinguir reprovação em banca de rejeição de proposta:
         // a presença de uma Entrega do tipo Final.
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act
@@ -188,6 +199,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
         // Arrange — regressão: garante que a validação de arquivo obrigatório
         // (que já existia antes da correção) continua funcionando
         var (factory, bancaId, _) = await PrepararCenarioComBancaPendente();
+        using var _fd = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         var form = new MultipartFormDataContent();
@@ -206,7 +218,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     public async Task BancaInexistente_DeveRetornarNotFound()
     {
         // Arrange
-        var factory = new TccApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act
@@ -230,6 +242,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
 
         // Arrange
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         // Act — primeiro lançamento: aprova o TCC normalmente
@@ -264,6 +277,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     {
         // Arrange
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
         const string motivoOriginal = "Não atingiu os critérios mínimos de avaliação.";
 
@@ -294,6 +308,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
     {
         // Arrange — banca ainda em AguardandoDefesa, então não é caso do Bug #5
         var (factory, bancaId, _) = await PrepararCenarioComBancaPendente();
+        using var _fd = factory;
         var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
         var form = new MultipartFormDataContent();
@@ -327,6 +342,7 @@ public class CoordenadorController_RegistrarResultadoBanca_Tests
             Thread.CurrentThread.CurrentUICulture = culturaPtBr;
 
             var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+            using var _ = factory;
             var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
 
             // Act — envia "85.5" no formato InvariantCulture (igual ao Client real)

--- a/TccManager.Tests/Controllers/NotificacaoIntegracao_Tests.cs
+++ b/TccManager.Tests/Controllers/NotificacaoIntegracao_Tests.cs
@@ -9,6 +9,7 @@ using TccManager.Api.Services.Email;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
 using TccManager.Tests.Services.Email;
 using Xunit;
 
@@ -29,7 +30,7 @@ public class NotificacaoIntegracao_Tests
     private const int idAvaliador1 = 21;
     private const int idAvaliador2 = 22;
 
-    private sealed class FactoryComFilaFake : TccApiFactory
+    private sealed class FactoryComFilaFake : WebRootIsolatedApiFactory
     {
         private readonly FakeEmailQueue _fila;
 

--- a/TccManager.Tests/Controllers/Paginacao_Integracao_Tests.cs
+++ b/TccManager.Tests/Controllers/Paginacao_Integracao_Tests.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Net.Http.Json;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+public class Paginacao_Integracao_Tests
+{
+    private const int idCoordenador = 1;
+    private const int idProfessor = 500;
+
+    // ─────────────────────────── GET /api/coordenador/professores ───────────────────────────
+
+    private static async Task<TccApiFactory> FactoryComProfessores(int quantidade)
+    {
+        var factory = new TccApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        for (int i = 1; i <= quantidade; i++)
+        {
+            context.Usuarios.Add(new Usuario
+            {
+                Id = i,
+                Nome = $"Prof {i:D3}",
+                Email = $"prof{i}@teste.com",
+                SenhaHash = "x",
+                Tipo = TipoUsuario.Professor,
+                Ativo = true
+            });
+        }
+        await context.SaveChangesAsync();
+        return factory;
+    }
+
+    [Fact]
+    public async Task GetProfessores_RetornaEnvelopePagedResult()
+    {
+        var factory = await FactoryComProfessores(3);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/professores");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(3, pagina!.TotalCount);
+        Assert.Equal(1, pagina.TotalPages);
+        Assert.Equal(1, pagina.CurrentPage);
+        Assert.Equal(3, pagina.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetProfessores_TotalCountRefleteTotalReal_MesmoComPaginaParcial()
+    {
+        var factory = await FactoryComProfessores(25);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/professores?page=2&pageSize=10");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(25, pagina!.TotalCount);
+        Assert.Equal(3, pagina.TotalPages);
+        Assert.Equal(2, pagina.CurrentPage);
+        Assert.Equal(10, pagina.Items.Count);
+        // Ordenação por Nome mantida: página 2 começa em Prof 011.
+        Assert.Equal("Prof 011", pagina.Items.First().Nome);
+    }
+
+    [Fact]
+    public async Task GetProfessores_PageSizeAlto_RetornaTodos_CenarioDropdown()
+    {
+        var factory = await FactoryComProfessores(30);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/professores?pageSize={PaginacaoQuery.MaxPageSize}");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(30, pagina!.TotalCount);
+        Assert.Equal(30, pagina.Items.Count);
+        Assert.Equal(1, pagina.TotalPages);
+    }
+
+    [Fact]
+    public async Task GetProfessores_ValoresNaoNumericos_NaoRetornam400_UsamDefaults()
+    {
+        var factory = await FactoryComProfessores(3);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/professores?page=abc&pageSize=xyz");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(PaginacaoQuery.DefaultPage, pagina!.CurrentPage);
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, pagina.PageSize);
+        Assert.Equal(3, pagina.TotalCount);
+    }
+
+    [Fact]
+    public async Task GetProfessores_PageMenorQueUm_ClampaParaUm_SemErro()
+    {
+        var factory = await FactoryComProfessores(5);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/professores?page=0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(1, pagina!.CurrentPage);
+    }
+
+    [Fact]
+    public async Task GetProfessores_PageSizeAcimaDoMaximo_ClampaPara100()
+    {
+        var factory = await FactoryComProfessores(3);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/professores?pageSize=9999");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<ProfessorResumoDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(PaginacaoQuery.MaxPageSize, pagina!.PageSize);
+    }
+
+    // ─────────────────────────── GET /api/orientador/dashboard ───────────────────────────
+
+    private static async Task<TccApiFactory> FactoryComPropostasPendentes(int quantidade)
+    {
+        var factory = new TccApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        context.Usuarios.Add(new Usuario
+        {
+            Id = idProfessor,
+            Nome = "Professor Orientador",
+            Email = "orientador@teste.com",
+            SenhaHash = "x",
+            Tipo = TipoUsuario.Professor,
+            Ativo = true
+        });
+
+        for (int i = 1; i <= quantidade; i++)
+        {
+            var alunoId = 1000 + i;
+            context.Usuarios.Add(new Usuario
+            {
+                Id = alunoId,
+                Nome = $"Aluno {i:D3}",
+                Email = $"aluno{i}@teste.com",
+                SenhaHash = "x",
+                Tipo = TipoUsuario.Aluno,
+                Ativo = true
+            });
+            context.Tccs.Add(new Tcc
+            {
+                Titulo = $"Proposta {i:D3}",
+                Resumo = "Resumo",
+                AlunoId = alunoId,
+                Status = StatusTcc.Pendente,
+                DataCriacao = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(i)
+            });
+        }
+        await context.SaveChangesAsync();
+        return factory;
+    }
+
+    [Fact]
+    public async Task GetDashboard_PropostasPendentes_RetornaEnvelopePagedResult()
+    {
+        var factory = await FactoryComPropostasPendentes(5);
+        var client = factory.CreateClientAutenticado(idProfessor, "Professor");
+
+        var response = await client.GetAsync("/api/orientador/dashboard");
+
+        response.EnsureSuccessStatusCode();
+        var dashboard = await response.Content.ReadFromJsonAsync<DashboardOrientadorDto>();
+
+        Assert.NotNull(dashboard);
+        Assert.NotNull(dashboard!.PropostasPendentes);
+        Assert.Equal(5, dashboard.PropostasPendentes.TotalCount);
+        Assert.Equal(1, dashboard.PropostasPendentes.CurrentPage);
+        Assert.Equal(5, dashboard.PropostasPendentes.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetDashboard_PropostasPendentes_TotalCountRefleteTotal_ComPaginaParcial()
+    {
+        var factory = await FactoryComPropostasPendentes(25);
+        var client = factory.CreateClientAutenticado(idProfessor, "Professor");
+
+        var response = await client.GetAsync("/api/orientador/dashboard?page=2&pageSize=10");
+
+        response.EnsureSuccessStatusCode();
+        var dashboard = await response.Content.ReadFromJsonAsync<DashboardOrientadorDto>();
+
+        Assert.NotNull(dashboard);
+        var pendentes = dashboard!.PropostasPendentes;
+        Assert.Equal(25, pendentes.TotalCount);
+        Assert.Equal(3, pendentes.TotalPages);
+        Assert.Equal(2, pendentes.CurrentPage);
+        Assert.Equal(10, pendentes.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetDashboard_PropostasPendentes_OrdenadasPorDataCriacaoDescendente()
+    {
+        var factory = await FactoryComPropostasPendentes(5);
+        var client = factory.CreateClientAutenticado(idProfessor, "Professor");
+
+        var response = await client.GetAsync("/api/orientador/dashboard");
+
+        response.EnsureSuccessStatusCode();
+        var dashboard = await response.Content.ReadFromJsonAsync<DashboardOrientadorDto>();
+
+        var itens = dashboard!.PropostasPendentes.Items;
+        // Proposta 005 tem a maior DataCriacao (mais recente) => vem primeiro.
+        Assert.Equal("Proposta 005", itens.First().Titulo);
+        var datas = itens.Select(i => i.DataCriacao).ToList();
+        Assert.Equal(datas.OrderByDescending(d => d).ToList(), datas);
+    }
+
+    [Fact]
+    public async Task GetDashboard_PageSizeAlto_Funciona()
+    {
+        var factory = await FactoryComPropostasPendentes(30);
+        var client = factory.CreateClientAutenticado(idProfessor, "Professor");
+
+        var response = await client.GetAsync($"/api/orientador/dashboard?pageSize={PaginacaoQuery.MaxPageSize}");
+
+        response.EnsureSuccessStatusCode();
+        var dashboard = await response.Content.ReadFromJsonAsync<DashboardOrientadorDto>();
+
+        Assert.Equal(30, dashboard!.PropostasPendentes.TotalCount);
+        Assert.Equal(30, dashboard.PropostasPendentes.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetDashboard_ValoresNaoNumericos_NaoRetornam400()
+    {
+        var factory = await FactoryComPropostasPendentes(3);
+        var client = factory.CreateClientAutenticado(idProfessor, "Professor");
+
+        var response = await client.GetAsync("/api/orientador/dashboard?page=foo&pageSize=bar");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var dashboard = await response.Content.ReadFromJsonAsync<DashboardOrientadorDto>();
+
+        Assert.Equal(PaginacaoQuery.DefaultPage, dashboard!.PropostasPendentes.CurrentPage);
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, dashboard.PropostasPendentes.PageSize);
+    }
+}

--- a/TccManager.Tests/Controllers/SanitizacaoXss_Integracao_Tests.cs
+++ b/TccManager.Tests/Controllers/SanitizacaoXss_Integracao_Tests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
 using Xunit;
 
 namespace TccManager.Tests.Controllers;
@@ -136,9 +137,9 @@ public class SanitizacaoXss_Integracao_Tests
 
     // ── Caminho multipart/form-data ─────────────────────────────────────────
 
-    private async Task<(TccApiFactory factory, int bancaId, int tccId)> PrepararCenarioComBancaPendente()
+    private async Task<(WebRootIsolatedApiFactory factory, int bancaId, int tccId)> PrepararCenarioComBancaPendente()
     {
-        var factory = new TccApiFactory();
+        var factory = new WebRootIsolatedApiFactory();
         using var context = factory.CriarContextoDireto();
 
         context.Usuarios.Add(new Usuario { Id = ID_ALUNO, Nome = "Aluno Teste", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true });
@@ -182,6 +183,7 @@ public class SanitizacaoXss_Integracao_Tests
     {
         // Arrange
         var (factory, bancaId, tccId) = await PrepararCenarioComBancaPendente();
+        using var _ = factory;
         var client = factory.CreateClientAutenticado(ID_COORDENADOR, "Coordenador");
 
         var form = new MultipartFormDataContent();

--- a/TccManager.Tests/Controllers/TccController_EnviarEntrega_Tests.cs
+++ b/TccManager.Tests/Controllers/TccController_EnviarEntrega_Tests.cs
@@ -1,0 +1,312 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+public class TccController_EnviarEntrega_Tests
+{
+    private const int idAluno = 10;
+    private const int idProfessor = 20;
+
+    /// <summary>
+    /// Variante da <see cref="TccApiFactory"/> que redireciona o WebRootPath do host de
+    /// teste para um diretório temporário isolado por execução. O caminho de sucesso
+    /// (RF4) grava fisicamente o arquivo em <c>WebRootPath/uploads/entregas</c>; sem esse
+    /// redirecionamento os arquivos iriam para o wwwroot real do projeto TccManager.Api.
+    /// O diretório é criado no construtor e removido no Dispose (mesmo em caso de falha),
+    /// para não poluir o repositório nem acumular resíduo entre execuções.
+    /// </summary>
+    private sealed class EnviarEntregaApiFactory : TccApiFactory
+    {
+        public readonly string WebRootTemp;
+
+        public EnviarEntregaApiFactory()
+        {
+            WebRootTemp = Path.Combine(
+                Path.GetTempPath(),
+                "siga-tcc-tests",
+                "webroot",
+                Guid.NewGuid().ToString());
+            Directory.CreateDirectory(WebRootTemp);
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.UseWebRoot(WebRootTemp);
+        }
+
+        public string PastaEntregas => Path.Combine(WebRootTemp, "uploads", "entregas");
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                try
+                {
+                    if (Directory.Exists(WebRootTemp))
+                        Directory.Delete(WebRootTemp, recursive: true);
+                }
+                catch
+                {
+                    // Limpeza best-effort: um arquivo eventualmente travado no SO não deve
+                    // derrubar o teste nem mascarar o resultado real da asserção.
+                }
+            }
+        }
+    }
+
+    private static async Task<int> SemearTccAsync(
+        TccApiFactory factory,
+        StatusTcc status,
+        bool comOrientador,
+        bool comEntregaFinal = false)
+    {
+        using var context = factory.CriarContextoDireto();
+
+        context.Usuarios.Add(new Usuario
+        {
+            Id = idAluno,
+            Nome = "Aluno Teste",
+            Email = "aluno@teste.com",
+            SenhaHash = "x",
+            Tipo = TipoUsuario.Aluno,
+            Ativo = true
+        });
+
+        if (comOrientador)
+        {
+            context.Usuarios.Add(new Usuario
+            {
+                Id = idProfessor,
+                Nome = "Professor Teste",
+                Email = "prof@teste.com",
+                SenhaHash = "x",
+                Tipo = TipoUsuario.Professor,
+                Ativo = true
+            });
+        }
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC de Teste",
+            Resumo = "Resumo de teste",
+            AlunoId = idAluno,
+            OrientadorId = comOrientador ? idProfessor : null,
+            Status = status,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        if (comEntregaFinal)
+        {
+            context.Entregas.Add(new Entrega
+            {
+                TccId = tcc.Id,
+                Titulo = "Versão Final",
+                ArquivoCaminho = "/uploads/entregas/fake.pdf",
+                Tipo = TipoEntrega.Final,
+                DataEnvio = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        return tcc.Id;
+    }
+
+    private static MultipartFormDataContent MontarFormEntrega(
+        string tituloEntrega,
+        TipoEntrega tipo,
+        string nomeArquivo,
+        string contentType = "application/pdf")
+    {
+        var form = new MultipartFormDataContent();
+        form.Add(new StringContent(tituloEntrega), "tituloEntrega");
+        form.Add(new StringContent(tipo.ToString()), "tipo");
+
+        // Bytes mínimos "%PDF" só para passar da validação de "arquivo obrigatório";
+        // é a EXTENSÃO do nomeArquivo que determina o resultado do RF5.
+        var arquivo = new ByteArrayContent(new byte[] { 0x25, 0x50, 0x44, 0x46 });
+        arquivo.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        form.Add(arquivo, "arquivo", nomeArquivo);
+
+        return form;
+    }
+
+    // RF1 — bloqueio de entrega Final sem OrientadorId (variante RN03)
+    [Fact]
+    public async Task RF1_EntregaFinal_SemOrientador_DeveRetornarBadRequest()
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Versão Final", TipoEntrega.Final, "entrega.pdf"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var corpo = await response.Content.ReadAsStringAsync();
+        Assert.Contains("RN03", corpo, StringComparison.OrdinalIgnoreCase);
+
+        using var context = factory.CriarContextoDireto();
+        var houveEntrega = await context.Entregas.AnyAsync(e => e.TccId == tccId);
+        Assert.False(houveEntrega);
+    }
+
+    // RF2 — bloqueio quando o TCC não está com Status = Aprovado
+    [Theory]
+    [InlineData(StatusTcc.Pendente)]
+    [InlineData(StatusTcc.EmAndamento)]
+    [InlineData(StatusTcc.AguardandoDefesa)]
+    [InlineData(StatusTcc.Finalizado)]
+    public async Task RF2_TccNaoAprovado_DeveRetornarBadRequest(StatusTcc status)
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, status, comOrientador: true);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Entrega Parcial", TipoEntrega.Parcial, "entrega.pdf"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var corpo = await response.Content.ReadAsStringAsync();
+        Assert.Contains("aprovado", corpo, StringComparison.OrdinalIgnoreCase);
+
+        using var context = factory.CriarContextoDireto();
+        var houveEntrega = await context.Entregas.AnyAsync(e => e.TccId == tccId);
+        Assert.False(houveEntrega);
+    }
+
+    // RF3 — bloqueio de reenvio quando já existe uma Entrega Tipo=Final
+    [Fact]
+    public async Task RF3_ReenvioComEntregaFinalExistente_DeveRetornarBadRequest()
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(
+            factory, StatusTcc.Aprovado, comOrientador: true, comEntregaFinal: true);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Nova Parcial", TipoEntrega.Parcial, "entrega.pdf"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var corpo = await response.Content.ReadAsStringAsync();
+        Assert.Contains("FINAL", corpo, StringComparison.OrdinalIgnoreCase);
+
+        // Nenhuma nova entrega deve ser gravada além da Final pré-existente
+        using var context = factory.CriarContextoDireto();
+        var totalEntregas = await context.Entregas.CountAsync(e => e.TccId == tccId);
+        Assert.Equal(1, totalEntregas);
+    }
+
+    // RF4 — caminho de sucesso: entrega Parcial (não exige orientador)
+    [Fact]
+    public async Task RF4_EntregaParcial_ComTccAprovado_DeveRetornarOk()
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Entrega Parcial", TipoEntrega.Parcial, "entrega.pdf"));
+
+        response.EnsureSuccessStatusCode();
+
+        using var context = factory.CriarContextoDireto();
+        var entrega = await context.Entregas.SingleAsync(e => e.TccId == tccId);
+        Assert.Equal(TipoEntrega.Parcial, entrega.Tipo);
+        Assert.Equal("Entrega Parcial", entrega.Titulo);
+        Assert.StartsWith("/uploads/entregas/", entrega.ArquivoCaminho);
+
+        // O arquivo físico deve ter sido gravado no web root temporário isolado,
+        // e não no wwwroot real do projeto.
+        Assert.True(Directory.Exists(factory.PastaEntregas));
+        Assert.Single(Directory.GetFiles(factory.PastaEntregas));
+    }
+
+    // RF4 — caminho de sucesso: entrega Final com orientador definido
+    [Fact]
+    public async Task RF4_EntregaFinal_ComOrientador_DeveRetornarOk()
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: true);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Versão Final", TipoEntrega.Final, "entrega.pdf"));
+
+        response.EnsureSuccessStatusCode();
+
+        using var context = factory.CriarContextoDireto();
+        var entrega = await context.Entregas.SingleAsync(e => e.TccId == tccId);
+        Assert.Equal(TipoEntrega.Final, entrega.Tipo);
+
+        Assert.True(Directory.Exists(factory.PastaEntregas));
+        Assert.Single(Directory.GetFiles(factory.PastaEntregas));
+    }
+
+    // RF5 — bloqueio por extensão de arquivo não permitida
+    [Theory]
+    [InlineData("entrega.exe")]
+    [InlineData("entrega.txt")]
+    [InlineData("entrega.png")]
+    [InlineData("entrega")]
+    public async Task RF5_ExtensaoNaoPermitida_DeveRetornarBadRequest(string nomeArquivo)
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: true);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Entrega Parcial", TipoEntrega.Parcial, nomeArquivo));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var corpo = await response.Content.ReadAsStringAsync();
+        Assert.Contains("formato", corpo, StringComparison.OrdinalIgnoreCase);
+
+        using var context = factory.CriarContextoDireto();
+        var houveEntrega = await context.Entregas.AnyAsync(e => e.TccId == tccId);
+        Assert.False(houveEntrega);
+    }
+
+    // RF5 — extensões permitidas devem ser aceitas (complemento do caso de sucesso)
+    [Theory]
+    [InlineData("entrega.pdf", "application/pdf")]
+    [InlineData("entrega.doc", "application/msword")]
+    [InlineData("entrega.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData("entrega.zip", "application/zip")]
+    public async Task RF5_ExtensaoPermitida_DeveRetornarOk(string nomeArquivo, string contentType)
+    {
+        using var factory = new EnviarEntregaApiFactory();
+        var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
+        var client = factory.CreateClientAutenticado(idAluno, "Aluno");
+
+        var response = await client.PostAsync(
+            "/api/tcc/entregas",
+            MontarFormEntrega("Entrega Parcial", TipoEntrega.Parcial, nomeArquivo, contentType));
+
+        response.EnsureSuccessStatusCode();
+
+        using var context = factory.CriarContextoDireto();
+        var houveEntrega = await context.Entregas.AnyAsync(e => e.TccId == tccId);
+        Assert.True(houveEntrega);
+    }
+}

--- a/TccManager.Tests/Controllers/TccController_EnviarEntrega_Tests.cs
+++ b/TccManager.Tests/Controllers/TccController_EnviarEntrega_Tests.cs
@@ -1,9 +1,9 @@
 using System.Net;
 using System.Net.Http.Headers;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
 using Xunit;
 
 namespace TccManager.Tests.Controllers;
@@ -12,56 +12,6 @@ public class TccController_EnviarEntrega_Tests
 {
     private const int idAluno = 10;
     private const int idProfessor = 20;
-
-    /// <summary>
-    /// Variante da <see cref="TccApiFactory"/> que redireciona o WebRootPath do host de
-    /// teste para um diretório temporário isolado por execução. O caminho de sucesso
-    /// (RF4) grava fisicamente o arquivo em <c>WebRootPath/uploads/entregas</c>; sem esse
-    /// redirecionamento os arquivos iriam para o wwwroot real do projeto TccManager.Api.
-    /// O diretório é criado no construtor e removido no Dispose (mesmo em caso de falha),
-    /// para não poluir o repositório nem acumular resíduo entre execuções.
-    /// </summary>
-    private sealed class EnviarEntregaApiFactory : TccApiFactory
-    {
-        public readonly string WebRootTemp;
-
-        public EnviarEntregaApiFactory()
-        {
-            WebRootTemp = Path.Combine(
-                Path.GetTempPath(),
-                "siga-tcc-tests",
-                "webroot",
-                Guid.NewGuid().ToString());
-            Directory.CreateDirectory(WebRootTemp);
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            base.ConfigureWebHost(builder);
-            builder.UseWebRoot(WebRootTemp);
-        }
-
-        public string PastaEntregas => Path.Combine(WebRootTemp, "uploads", "entregas");
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-
-            if (disposing)
-            {
-                try
-                {
-                    if (Directory.Exists(WebRootTemp))
-                        Directory.Delete(WebRootTemp, recursive: true);
-                }
-                catch
-                {
-                    // Limpeza best-effort: um arquivo eventualmente travado no SO não deve
-                    // derrubar o teste nem mascarar o resultado real da asserção.
-                }
-            }
-        }
-    }
 
     private static async Task<int> SemearTccAsync(
         TccApiFactory factory,
@@ -145,7 +95,7 @@ public class TccController_EnviarEntrega_Tests
     [Fact]
     public async Task RF1_EntregaFinal_SemOrientador_DeveRetornarBadRequest()
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 
@@ -171,7 +121,7 @@ public class TccController_EnviarEntrega_Tests
     [InlineData(StatusTcc.Finalizado)]
     public async Task RF2_TccNaoAprovado_DeveRetornarBadRequest(StatusTcc status)
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, status, comOrientador: true);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 
@@ -193,7 +143,7 @@ public class TccController_EnviarEntrega_Tests
     [Fact]
     public async Task RF3_ReenvioComEntregaFinalExistente_DeveRetornarBadRequest()
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(
             factory, StatusTcc.Aprovado, comOrientador: true, comEntregaFinal: true);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
@@ -217,7 +167,7 @@ public class TccController_EnviarEntrega_Tests
     [Fact]
     public async Task RF4_EntregaParcial_ComTccAprovado_DeveRetornarOk()
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 
@@ -243,7 +193,7 @@ public class TccController_EnviarEntrega_Tests
     [Fact]
     public async Task RF4_EntregaFinal_ComOrientador_DeveRetornarOk()
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: true);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 
@@ -269,7 +219,7 @@ public class TccController_EnviarEntrega_Tests
     [InlineData("entrega")]
     public async Task RF5_ExtensaoNaoPermitida_DeveRetornarBadRequest(string nomeArquivo)
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: true);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 
@@ -295,7 +245,7 @@ public class TccController_EnviarEntrega_Tests
     [InlineData("entrega.zip", "application/zip")]
     public async Task RF5_ExtensaoPermitida_DeveRetornarOk(string nomeArquivo, string contentType)
     {
-        using var factory = new EnviarEntregaApiFactory();
+        using var factory = new WebRootIsolatedApiFactory();
         var tccId = await SemearTccAsync(factory, StatusTcc.Aprovado, comOrientador: false);
         var client = factory.CreateClientAutenticado(idAluno, "Aluno");
 

--- a/TccManager.Tests/Extensions/QueryablePagingExtensionsTests.cs
+++ b/TccManager.Tests/Extensions/QueryablePagingExtensionsTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.EntityFrameworkCore;
+using TccManager.Api.Data;
+using TccManager.Api.Extensions;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Extensions;
+
+public class QueryablePagingExtensionsTests
+{
+    private static AppDbContext CriarContexto()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<AppDbContext> ContextoComProfessores(int quantidade)
+    {
+        var context = CriarContexto();
+        for (int i = 1; i <= quantidade; i++)
+        {
+            context.Usuarios.Add(new Usuario
+            {
+                Id = i,
+                Nome = $"Prof {i:D3}",
+                Email = $"prof{i}@teste.com",
+                SenhaHash = "x",
+                Tipo = TipoUsuario.Professor,
+                Ativo = true
+            });
+        }
+        await context.SaveChangesAsync();
+        return context;
+    }
+
+    [Fact]
+    public async Task ValoresValidos_AplicamSkipTakeCorretamente()
+    {
+        using var context = await ContextoComProfessores(25);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 2, PageSize = 10 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(10, resultado.Items.Count);
+        // Página 2 com 10 por página => itens 11..20 (Prof 011..Prof 020).
+        Assert.Equal("Prof 011", resultado.Items.First().Nome);
+        Assert.Equal("Prof 020", resultado.Items.Last().Nome);
+    }
+
+    [Fact]
+    public async Task Metadados_RefletemTotalReal_MesmoComPoucosItensNaPagina()
+    {
+        using var context = await ContextoComProfessores(25);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 3, PageSize = 10 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        // Última página tem apenas 5 itens, mas o total permanece 25.
+        Assert.Equal(5, resultado.Items.Count);
+        Assert.Equal(25, resultado.TotalCount);
+        Assert.Equal(3, resultado.TotalPages);
+        Assert.Equal(3, resultado.CurrentPage);
+        Assert.Equal(10, resultado.PageSize);
+    }
+
+    [Fact]
+    public async Task PrimeiraPagina_ComecaDoInicioSemSkip()
+    {
+        using var context = await ContextoComProfessores(15);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 1, PageSize = 10 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(10, resultado.Items.Count);
+        Assert.Equal("Prof 001", resultado.Items.First().Nome);
+    }
+
+    [Fact]
+    public async Task PageSizeMaiorQueTotal_RetornaTodosOsItens()
+    {
+        using var context = await ContextoComProfessores(3);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 1, PageSize = PaginacaoQuery.MaxPageSize };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(3, resultado.Items.Count);
+        Assert.Equal(3, resultado.TotalCount);
+        Assert.Equal(1, resultado.TotalPages);
+    }
+
+    [Fact]
+    public async Task PaginaAlemDoFim_ClampaParaUltimaPaginaReal()
+    {
+        // Regressão de segurança: Page muito além do fim não deve mais retornar vazio
+        // com CurrentPage = valor pedido — isso permitia overflow de Int32 em
+        // (Page-1)*PageSize para Page muito grande (ex.: ?page=21474837), gerando
+        // Skip negativo e 500. Agora a página é clampada ao intervalo real.
+        using var context = await ContextoComProfessores(5);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 10, PageSize = 10 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(5, resultado.Items.Count);
+        Assert.Equal(5, resultado.TotalCount);
+        Assert.Equal(1, resultado.TotalPages);
+        Assert.Equal(1, resultado.CurrentPage);
+    }
+
+    [Fact]
+    public async Task PaginaExtremamenteGrande_NaoLancaExcecaoPorOverflow()
+    {
+        using var context = await ContextoComProfessores(5);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = int.MaxValue, PageSize = 100 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(5, resultado.Items.Count);
+        Assert.Equal(1, resultado.CurrentPage);
+    }
+
+    [Fact]
+    public async Task QuerySemResultados_RetornaZerado()
+    {
+        using var context = CriarContexto();
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 1, PageSize = 20 };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Empty(resultado.Items);
+        Assert.Equal(0, resultado.TotalCount);
+        Assert.Equal(0, resultado.TotalPages);
+    }
+
+    [Theory]
+    [InlineData(10, 10, 1)]
+    [InlineData(11, 10, 2)]
+    [InlineData(20, 10, 2)]
+    [InlineData(21, 10, 3)]
+    [InlineData(1, 20, 1)]
+    public async Task TotalPages_UsaTetoDaDivisao(int totalItens, int pageSize, int totalPagesEsperado)
+    {
+        using var context = await ContextoComProfessores(totalItens);
+        var query = context.Usuarios.OrderBy(u => u.Nome);
+        var paginacao = new PaginacaoQuery { Page = 1, PageSize = pageSize };
+
+        var resultado = await query.ToPagedResultAsync(paginacao);
+
+        Assert.Equal(totalPagesEsperado, resultado.TotalPages);
+    }
+}

--- a/TccManager.Tests/Filters/FluentValidationBanca_Integracao_Tests.cs
+++ b/TccManager.Tests/Filters/FluentValidationBanca_Integracao_Tests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Filters;
+
+/// <summary>
+/// Testes de integração do FluentValidationActionFilter através do pipeline HTTP real.
+/// Foco: confirmar que uma falha de FluentValidation (data no passado) produz um 400 com
+/// o mesmo formato ValidationProblemDetails (RFC 7807) que uma falha de DataAnnotations.
+/// </summary>
+public class FluentValidationBanca_Integracao_Tests
+{
+    private const int idCoordenador = 1;
+    private const int idAluno = 10;
+    private const int idOrientador = 20;
+    private const int idAvaliador1 = 21;
+    private const int idAvaliador2 = 22;
+
+    private async Task<(TccApiFactory factory, int tccId)> PrepararTccAguardandoDefesa()
+    {
+        var factory = new TccApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        context.Usuarios.AddRange(
+            new Usuario { Id = idAluno, Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true },
+            new Usuario { Id = idOrientador, Nome = "Orientador", Email = "orientador@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+            new Usuario { Id = idAvaliador1, Nome = "Avaliador 1", Email = "av1@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true },
+            new Usuario { Id = idAvaliador2, Nome = "Avaliador 2", Email = "av2@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true });
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC de Teste",
+            Resumo = "Resumo",
+            AlunoId = idAluno,
+            OrientadorId = idOrientador,
+            Status = StatusTcc.AguardandoDefesa,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        return (factory, tcc.Id);
+    }
+
+    [Fact]
+    public async Task DataNoPassado_DeveRetornar400_ComValidationProblemDetails_ChaveDataHora()
+    {
+        // Arrange — DTO válido em tudo (Local preenchido, 2 avaliadores), exceto a data,
+        // que está no passado — a única violação deve vir do FluentValidation.
+        var (factory, tccId) = await PrepararTccAguardandoDefesa();
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var dto = new AgendarBancaDto
+        {
+            DataHora = DateTime.Now.AddDays(-7),
+            Local = "Sala 101",
+            ProfessoresIds = new List<int> { idAvaliador1, idAvaliador2 },
+            MembrosExternosIds = new List<int>()
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/coordenador/tcc/{tccId}/banca", dto);
+
+        // Assert — status e content-type do padrão problem+details
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var errors = doc.RootElement.GetProperty("errors");
+        Assert.True(errors.TryGetProperty(nameof(AgendarBancaDto.DataHora), out var mensagens));
+        Assert.Contains(
+            "A data e hora da banca devem ser futuras.",
+            mensagens.EnumerateArray().Select(m => m.GetString()));
+
+        // Assert — o curto-circuito impediu qualquer persistência
+        using var context = factory.CriarContextoDireto();
+        Assert.False(await context.Banca.AnyAsync(b => b.TccId == tccId));
+    }
+
+    [Fact]
+    public async Task FormatoDeErro_FluentValidation_DeveSerIgualAoDeDataAnnotations()
+    {
+        // Arrange
+        var (factory, tccId) = await PrepararTccAguardandoDefesa();
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        // Falha de FluentValidation: data no passado, resto válido.
+        var dtoFluent = new AgendarBancaDto
+        {
+            DataHora = DateTime.Now.AddDays(-7),
+            Local = "Sala 101",
+            ProfessoresIds = new List<int> { idAvaliador1, idAvaliador2 },
+            MembrosExternosIds = new List<int>()
+        };
+
+        // Falha de DataAnnotations: Local vazio ([Required]), data no futuro (default) para
+        // que o FluentValidation nem chegue a rodar — isola a 1ª camada.
+        var dtoDataAnnotations = new AgendarBancaDto
+        {
+            DataHora = DateTime.Now.AddDays(7),
+            Local = "",
+            ProfessoresIds = new List<int> { idAvaliador1, idAvaliador2 },
+            MembrosExternosIds = new List<int>()
+        };
+
+        // Act
+        var respFluent = await client.PostAsJsonAsync($"/api/coordenador/tcc/{tccId}/banca", dtoFluent);
+        var respDataAnnotations = await client.PostAsJsonAsync($"/api/coordenador/tcc/{tccId}/banca", dtoDataAnnotations);
+
+        // Assert — ambas 400 problem+json
+        Assert.Equal(HttpStatusCode.BadRequest, respFluent.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, respDataAnnotations.StatusCode);
+        Assert.Equal("application/problem+json", respFluent.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("application/problem+json", respDataAnnotations.Content.Headers.ContentType?.MediaType);
+
+        using var docFluent = JsonDocument.Parse(await respFluent.Content.ReadAsStringAsync());
+        using var docData = JsonDocument.Parse(await respDataAnnotations.Content.ReadAsStringAsync());
+
+        // Assert — mesmo conjunto de propriedades de topo (type, title, status, errors, traceId...)
+        Assert.Equal(PropriedadesDeTopo(docFluent), PropriedadesDeTopo(docData));
+
+        // Assert — mesmo title e status
+        Assert.Equal(
+            docData.RootElement.GetProperty("title").GetString(),
+            docFluent.RootElement.GetProperty("title").GetString());
+        Assert.Equal(
+            docData.RootElement.GetProperty("status").GetInt32(),
+            docFluent.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal(400, docFluent.RootElement.GetProperty("status").GetInt32());
+
+        // Assert — a chave de erro corresponde ao nome da propriedade do DTO em cada caso
+        Assert.True(docFluent.RootElement.GetProperty("errors")
+            .TryGetProperty(nameof(AgendarBancaDto.DataHora), out _));
+        Assert.True(docData.RootElement.GetProperty("errors")
+            .TryGetProperty(nameof(AgendarBancaDto.Local), out _));
+    }
+
+    private static IEnumerable<string> PropriedadesDeTopo(JsonDocument doc) =>
+        doc.RootElement.EnumerateObject().Select(p => p.Name).OrderBy(n => n).ToList();
+}

--- a/TccManager.Tests/Fixtures/WebRootIsolatedApiFactory.cs
+++ b/TccManager.Tests/Fixtures/WebRootIsolatedApiFactory.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Hosting;
+
+namespace TccManager.Tests.Fixtures;
+
+/// <summary>
+/// Variante da <see cref="TccApiFactory"/> que redireciona o WebRootPath do host de teste
+/// para um diretório temporário isolado por execução. Os controllers que gravam arquivo
+/// (entregas via <c>TccController.EnviarEntrega</c>, atas via
+/// <c>CoordenadorController.RegistrarResultadoBanca</c>) resolvem o caminho base através de
+/// <c>IStorageService</c>/<c>LocalStorageService</c>, que por sua vez usa
+/// <c>IWebHostEnvironment.WebRootPath</c>. Sem esse redirecionamento os arquivos gravados
+/// durante os testes iriam para o wwwroot real do projeto TccManager.Api.
+///
+/// O diretório temporário é criado no construtor e removido no Dispose (mesmo em caso de
+/// falha do teste), para não poluir o repositório nem acumular resíduo entre execuções.
+/// </summary>
+public class WebRootIsolatedApiFactory : TccApiFactory
+{
+    public readonly string WebRootTemp;
+
+    public WebRootIsolatedApiFactory()
+    {
+        WebRootTemp = Path.Combine(
+            Path.GetTempPath(),
+            "siga-tcc-tests",
+            "webroot",
+            Guid.NewGuid().ToString());
+        Directory.CreateDirectory(WebRootTemp);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        builder.UseWebRoot(WebRootTemp);
+    }
+
+    public string PastaUploads(string categoria) => Path.Combine(WebRootTemp, "uploads", categoria);
+
+    public string PastaEntregas => PastaUploads("entregas");
+
+    public string PastaAtas => PastaUploads("atas");
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            try
+            {
+                if (Directory.Exists(WebRootTemp))
+                    Directory.Delete(WebRootTemp, recursive: true);
+            }
+            catch
+            {
+                // Limpeza best-effort: um arquivo eventualmente travado no SO não deve
+                // derrubar o teste nem mascarar o resultado real da asserção.
+            }
+        }
+    }
+}

--- a/TccManager.Tests/ModelBinding/PaginacaoQueryModelBinderTests.cs
+++ b/TccManager.Tests/ModelBinding/PaginacaoQueryModelBinderTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using TccManager.Api.ModelBinding;
+using TccManager.Shared.DTOs;
+using Xunit;
+
+namespace TccManager.Tests.ModelBinding;
+
+public class PaginacaoQueryModelBinderTests
+{
+    private static async Task<PaginacaoQuery> Bind(string? page, string? pageSize)
+    {
+        var binder = new PaginacaoQueryModelBinder();
+
+        var valores = new Dictionary<string, string?>();
+        if (page != null) valores["page"] = page;
+        if (pageSize != null) valores["pageSize"] = pageSize;
+
+        var context = new DefaultModelBindingContext
+        {
+            ValueProvider = new FakeValueProvider(valores)
+        };
+
+        await binder.BindModelAsync(context);
+
+        Assert.True(context.Result.IsModelSet);
+        return Assert.IsType<PaginacaoQuery>(context.Result.Model);
+    }
+
+    [Fact]
+    public async Task ValoresValidos_SaoPreservados()
+    {
+        var query = await Bind("3", "25");
+
+        Assert.Equal(3, query.Page);
+        Assert.Equal(25, query.PageSize);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("-999")]
+    public async Task PageMenorQueUm_ClampaParaUm(string page)
+    {
+        var query = await Bind(page, "20");
+
+        Assert.Equal(PaginacaoQuery.DefaultPage, query.Page);
+        Assert.Equal(1, query.Page);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    public async Task PageSizeMenorQueUm_ClampaParaDefault(string pageSize)
+    {
+        var query = await Bind("1", pageSize);
+
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, query.PageSize);
+        Assert.Equal(20, query.PageSize);
+    }
+
+    [Theory]
+    [InlineData("101", 100)]
+    [InlineData("500", 100)]
+    [InlineData("100", 100)]
+    public async Task PageSizeAcimaDoMaximo_ClampaParaMaximo(string pageSize, int esperado)
+    {
+        var query = await Bind("1", pageSize);
+
+        Assert.Equal(esperado, query.PageSize);
+        Assert.True(query.PageSize <= PaginacaoQuery.MaxPageSize);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("1.5")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task PageNaoNumerico_ClampaParaDefaultSemErro(string page)
+    {
+        var query = await Bind(page, "20");
+
+        Assert.Equal(PaginacaoQuery.DefaultPage, query.Page);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("10x")]
+    [InlineData("")]
+    public async Task PageSizeNaoNumerico_ClampaParaDefaultSemErro(string pageSize)
+    {
+        var query = await Bind("1", pageSize);
+
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, query.PageSize);
+    }
+
+    [Fact]
+    public async Task ParametrosAusentes_UsamOsDefaults()
+    {
+        var query = await Bind(null, null);
+
+        Assert.Equal(PaginacaoQuery.DefaultPage, query.Page);
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, query.PageSize);
+    }
+
+    [Fact]
+    public async Task BinderNuncaAdicionaErroDeModelState()
+    {
+        var binder = new PaginacaoQueryModelBinder();
+        var context = new DefaultModelBindingContext
+        {
+            ModelState = new ModelStateDictionary(),
+            ValueProvider = new FakeValueProvider(new Dictionary<string, string?>
+            {
+                ["page"] = "nao-numerico",
+                ["pageSize"] = "tambem-nao"
+            })
+        };
+
+        await binder.BindModelAsync(context);
+
+        Assert.True(context.ModelState.IsValid);
+        Assert.Equal(0, context.ModelState.ErrorCount);
+    }
+
+    private sealed class FakeValueProvider : IValueProvider
+    {
+        private readonly Dictionary<string, string?> _valores;
+
+        public FakeValueProvider(Dictionary<string, string?> valores) => _valores = valores;
+
+        public bool ContainsPrefix(string prefix) => _valores.ContainsKey(prefix);
+
+        public ValueProviderResult GetValue(string key)
+        {
+            if (_valores.TryGetValue(key, out var valor) && valor != null)
+                return new ValueProviderResult(new StringValues(valor));
+
+            return ValueProviderResult.None;
+        }
+    }
+}

--- a/TccManager.Tests/Services/Storage/LocalStorageServiceTests.cs
+++ b/TccManager.Tests/Services/Storage/LocalStorageServiceTests.cs
@@ -1,0 +1,203 @@
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using TccManager.Api.Services.Storage;
+
+namespace TccManager.Tests.Services.Storage;
+
+/// <summary>
+/// Testes unitários diretos de <see cref="LocalStorageService"/>: instanciam o serviço com um
+/// <see cref="IWebHostEnvironment"/> fake apontando para um diretório temporário isolado, sem
+/// subir o host via WebApplicationFactory. Cada teste usa sua própria pasta temporária e a
+/// remove no <see cref="Dispose"/>, para nunca tocar o wwwroot real do projeto.
+/// </summary>
+public class LocalStorageServiceTests : IDisposable
+{
+    private readonly string _webRootTemp;
+    private readonly LocalStorageService _sut;
+
+    public LocalStorageServiceTests()
+    {
+        _webRootTemp = Path.Combine(
+            Path.GetTempPath(),
+            "siga-tcc-tests",
+            "unit-storage",
+            Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_webRootTemp);
+
+        _sut = new LocalStorageService(new FakeWebHostEnvironment(_webRootTemp));
+    }
+
+    private static Stream ConteudoDe(string texto) => new MemoryStream(Encoding.UTF8.GetBytes(texto));
+
+    [Fact]
+    public async Task UploadAsync_ComEntrega_GravaArquivoFisicoERetornaCaminhoRelativoEsperado()
+    {
+        const string conteudo = "conteudo da entrega";
+        await using var stream = ConteudoDe(conteudo);
+
+        var caminhoRelativo = await _sut.UploadAsync(stream, "monografia.pdf", CategoriaArquivo.Entregas);
+
+        // Formato do caminho relativo: "/uploads/{categoria}/{guid}_{nomeSaneado}".
+        Assert.StartsWith("/uploads/entregas/", caminhoRelativo);
+        Assert.EndsWith("_monografia.pdf", caminhoRelativo);
+
+        var nomeArquivo = caminhoRelativo.Substring("/uploads/entregas/".Length);
+        var caminhoFisico = Path.Combine(_webRootTemp, "uploads", "entregas", nomeArquivo);
+        Assert.True(File.Exists(caminhoFisico), "O arquivo deveria ter sido gravado fisicamente na pasta de entregas.");
+        Assert.Equal(conteudo, await File.ReadAllTextAsync(caminhoFisico));
+
+        // O prefixo antes de "_monografia.pdf" deve ser um GUID válido.
+        var prefixoGuid = nomeArquivo.Substring(0, nomeArquivo.Length - "_monografia.pdf".Length);
+        Assert.True(Guid.TryParse(prefixoGuid, out _), $"Prefixo '{prefixoGuid}' deveria ser um GUID válido.");
+    }
+
+    [Fact]
+    public async Task UploadAsync_ChamadasSucessivas_GeramNomesUnicos()
+    {
+        await using var s1 = ConteudoDe("a");
+        await using var s2 = ConteudoDe("b");
+
+        var caminho1 = await _sut.UploadAsync(s1, "arquivo.pdf", CategoriaArquivo.Entregas);
+        var caminho2 = await _sut.UploadAsync(s2, "arquivo.pdf", CategoriaArquivo.Entregas);
+
+        Assert.NotEqual(caminho1, caminho2);
+        Assert.Equal(2, Directory.GetFiles(Path.Combine(_webRootTemp, "uploads", "entregas")).Length);
+    }
+
+    [Theory]
+    [InlineData("../../evil.txt", "evil.txt")]
+    [InlineData("..\\..\\evil.exe", "evil.exe")]
+    [InlineData("/etc/passwd", "passwd")]
+    [InlineData("../../../wwwroot/Program.cs", "Program.cs")]
+    public async Task UploadAsync_ComNomeContendoPathTraversal_NeutralizaComPathGetFileName(
+        string nomeMalicioso, string nomeEsperado)
+    {
+        await using var stream = ConteudoDe("payload");
+
+        var caminhoRelativo = await _sut.UploadAsync(stream, nomeMalicioso, CategoriaArquivo.Entregas);
+
+        // Regressão de segurança: o caminho retornado nunca deve escapar da pasta da categoria.
+        Assert.StartsWith("/uploads/entregas/", caminhoRelativo);
+        Assert.EndsWith($"_{nomeEsperado}", caminhoRelativo);
+        Assert.DoesNotContain("..", caminhoRelativo);
+
+        var pastaCategoria = Path.GetFullPath(Path.Combine(_webRootTemp, "uploads", "entregas"));
+
+        // O arquivo físico deve estar estritamente dentro da pasta de entregas.
+        var arquivosGravados = Directory.GetFiles(pastaCategoria);
+        Assert.Single(arquivosGravados);
+
+        var caminhoFisicoResolvido = Path.GetFullPath(arquivosGravados[0]);
+        Assert.StartsWith(pastaCategoria + Path.DirectorySeparatorChar, caminhoFisicoResolvido);
+        Assert.EndsWith($"_{nomeEsperado}", Path.GetFileName(caminhoFisicoResolvido));
+
+        // Nada foi criado fora da pasta de uploads (nenhum escape para o webroot ou acima).
+        var conteudoWebRoot = Directory.GetFileSystemEntries(_webRootTemp);
+        Assert.Single(conteudoWebRoot);
+        Assert.Equal(Path.Combine(_webRootTemp, "uploads"), conteudoWebRoot[0]);
+    }
+
+    [Fact]
+    public async Task UploadAsync_CategoriasDiferentes_GravamEmSubpastasDiferentes()
+    {
+        await using var streamEntrega = ConteudoDe("entrega");
+        await using var streamAta = ConteudoDe("ata");
+
+        var caminhoEntrega = await _sut.UploadAsync(streamEntrega, "entrega.pdf", CategoriaArquivo.Entregas);
+        var caminhoAta = await _sut.UploadAsync(streamAta, "ata.pdf", CategoriaArquivo.Atas);
+
+        Assert.StartsWith("/uploads/entregas/", caminhoEntrega);
+        Assert.StartsWith("/uploads/atas/", caminhoAta);
+
+        var pastaEntregas = Path.Combine(_webRootTemp, "uploads", "entregas");
+        var pastaAtas = Path.Combine(_webRootTemp, "uploads", "atas");
+
+        Assert.Single(Directory.GetFiles(pastaEntregas));
+        Assert.Single(Directory.GetFiles(pastaAtas));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ComArquivoExistente_RemoveArquivoFisico()
+    {
+        await using var stream = ConteudoDe("para deletar");
+        var caminhoRelativo = await _sut.UploadAsync(stream, "temporario.pdf", CategoriaArquivo.Atas);
+
+        var nomeArquivo = caminhoRelativo.Substring("/uploads/atas/".Length);
+        var caminhoFisico = Path.Combine(_webRootTemp, "uploads", "atas", nomeArquivo);
+        Assert.True(File.Exists(caminhoFisico));
+
+        await _sut.DeleteAsync(caminhoRelativo);
+
+        Assert.False(File.Exists(caminhoFisico), "O arquivo deveria ter sido removido por DeleteAsync.");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ComArquivoInexistente_NaoLancaExcecao()
+    {
+        var caminhoInexistente = $"/uploads/entregas/{Guid.NewGuid()}_nao-existe.pdf";
+
+        var excecao = await Record.ExceptionAsync(() => _sut.DeleteAsync(caminhoInexistente));
+
+        Assert.Null(excecao);
+    }
+
+    [Theory]
+    [InlineData("../../fora-do-uploads.txt")]
+    [InlineData("/uploads/../../fora-do-uploads.txt")]
+    [InlineData("uploads/../../../fora-do-uploads.txt")]
+    public async Task DeleteAsync_ComCaminhoQueEscapaDaPastaDeUploads_LancaInvalidOperationException(
+        string caminhoMalicioso)
+    {
+        // Regressão de segurança: um arquivo fora de wwwroot/uploads criado propositalmente
+        // para este teste NUNCA deve ser removido por um caminho que tente escapar via "..".
+        var caminhoForaDoUploads = Path.Combine(_webRootTemp, "fora-do-uploads.txt");
+        await File.WriteAllTextAsync(caminhoForaDoUploads, "não deveria ser apagado");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.DeleteAsync(caminhoMalicioso));
+
+        Assert.True(File.Exists(caminhoForaDoUploads), "DeleteAsync não deveria ter alcançado um arquivo fora de wwwroot/uploads.");
+    }
+
+    [Fact]
+    public async Task GetUrlAsync_RetornaOMesmoCaminhoRelativo_Identidade()
+    {
+        const string caminho = "/uploads/atas/abc_ata.pdf";
+
+        var url = await _sut.GetUrlAsync(caminho);
+
+        Assert.Equal(caminho, url);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_webRootTemp))
+                Directory.Delete(_webRootTemp, recursive: true);
+        }
+        catch
+        {
+            // Limpeza best-effort: um arquivo eventualmente travado no SO não deve
+            // derrubar o teste nem mascarar o resultado real da asserção.
+        }
+    }
+
+    private sealed class FakeWebHostEnvironment : IWebHostEnvironment
+    {
+        public FakeWebHostEnvironment(string webRootPath)
+        {
+            WebRootPath = webRootPath;
+            ContentRootPath = webRootPath;
+            WebRootFileProvider = new PhysicalFileProvider(webRootPath);
+            ContentRootFileProvider = new PhysicalFileProvider(webRootPath);
+        }
+
+        public string WebRootPath { get; set; }
+        public IFileProvider WebRootFileProvider { get; set; }
+        public string ApplicationName { get; set; } = "TccManager.Tests";
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; }
+        public string EnvironmentName { get; set; } = "Test";
+    }
+}

--- a/TccManager.Tests/Services/Storage/LocalStorageServiceTests.cs
+++ b/TccManager.Tests/Services/Storage/LocalStorageServiceTests.cs
@@ -66,13 +66,19 @@ public class LocalStorageServiceTests : IDisposable
     }
 
     [Theory]
-    [InlineData("../../evil.txt", "evil.txt")]
-    [InlineData("..\\..\\evil.exe", "evil.exe")]
-    [InlineData("/etc/passwd", "passwd")]
-    [InlineData("../../../wwwroot/Program.cs", "Program.cs")]
-    public async Task UploadAsync_ComNomeContendoPathTraversal_NeutralizaComPathGetFileName(
-        string nomeMalicioso, string nomeEsperado)
+    [InlineData("../../evil.txt")]
+    [InlineData("..\\..\\evil.exe")]
+    [InlineData("/etc/passwd")]
+    [InlineData("../../../wwwroot/Program.cs")]
+    public async Task UploadAsync_ComNomeContendoPathTraversal_NeutralizaComPathGetFileName(string nomeMalicioso)
     {
+        // Nota de portabilidade: Path.GetFileName só trata "\" como separador no Windows;
+        // no Linux (runner do CI), "\" é um caractere literal de nome de arquivo. Por isso o
+        // "nome esperado" é calculado com o mesmo Path.GetFileName usado em produção, em vez
+        // de um literal hardcoded — a propriedade de segurança verificada não é "o nome vira
+        // X", e sim "o arquivo nunca escapa da pasta da categoria", que vale nas duas plataformas.
+        var nomeEsperado = Path.GetFileName(nomeMalicioso);
+
         await using var stream = ConteudoDe("payload");
 
         var caminhoRelativo = await _sut.UploadAsync(stream, nomeMalicioso, CategoriaArquivo.Entregas);
@@ -80,7 +86,6 @@ public class LocalStorageServiceTests : IDisposable
         // Regressão de segurança: o caminho retornado nunca deve escapar da pasta da categoria.
         Assert.StartsWith("/uploads/entregas/", caminhoRelativo);
         Assert.EndsWith($"_{nomeEsperado}", caminhoRelativo);
-        Assert.DoesNotContain("..", caminhoRelativo);
 
         var pastaCategoria = Path.GetFullPath(Path.Combine(_webRootTemp, "uploads", "entregas"));
 

--- a/TccManager.Tests/Validators/AgendarBancaDtoValidatorTests.cs
+++ b/TccManager.Tests/Validators/AgendarBancaDtoValidatorTests.cs
@@ -1,0 +1,95 @@
+using TccManager.Api.Services;
+using TccManager.Api.Validators;
+using TccManager.Shared.DTOs;
+using Xunit;
+
+namespace TccManager.Tests.Validators;
+
+public class AgendarBancaDtoValidatorTests
+{
+    private const string MensagemEsperada = "A data e hora da banca devem ser futuras.";
+
+    private static AgendarBancaDto DtoComData(DateTime dataHora) => new()
+    {
+        DataHora = dataHora,
+        Local = "Sala 101",
+        ProfessoresIds = new List<int> { 21, 22 },
+        MembrosExternosIds = new List<int>()
+    };
+
+    [Fact]
+    public void DataClaramenteNoFuturo_DeveSerValida()
+    {
+        // "Agora" fixado no início de 2026; banca marcada para meados de 2026.
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var validator = new AgendarBancaDtoValidator(timeProvider);
+
+        var dto = DtoComData(new DateTime(2026, 6, 15, 10, 0, 0, DateTimeKind.Unspecified));
+
+        var result = validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void DataClaramenteNoPassado_DeveSerInvalida_ComPropriedadeEMensagemCertas()
+    {
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        var validator = new AgendarBancaDtoValidator(timeProvider);
+
+        var dto = DtoComData(new DateTime(2020, 1, 1, 10, 0, 0, DateTimeKind.Unspecified));
+
+        var result = validator.Validate(dto);
+
+        Assert.False(result.IsValid);
+        var erro = Assert.Single(result.Errors);
+        Assert.Equal(nameof(AgendarBancaDto.DataHora), erro.PropertyName);
+        Assert.Equal(MensagemEsperada, erro.ErrorMessage);
+    }
+
+    [Fact]
+    public void DataUmSegundoNoFuturo_DeveSerValida()
+    {
+        // Fronteira: a data (em Brasília) é convertida para UTC e comparada com o "agora".
+        // Derivamos o "agora" do próprio horário convertido para não depender do offset atual.
+        var dataHoraBrasilia = new DateTime(2026, 6, 15, 10, 0, 0, DateTimeKind.Unspecified);
+        var utcDaBanca = BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dataHoraBrasilia);
+
+        var agoraUmSegundoAntes = new DateTimeOffset(utcDaBanca.AddSeconds(-1), TimeSpan.Zero);
+        var validator = new AgendarBancaDtoValidator(new FixedTimeProvider(agoraUmSegundoAntes));
+
+        var result = validator.Validate(DtoComData(dataHoraBrasilia));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void DataExatamenteIgualAoAgora_DeveSerInvalida()
+    {
+        // A regra usa comparação estrita (>), então a fronteira exata é inválida.
+        var dataHoraBrasilia = new DateTime(2026, 6, 15, 10, 0, 0, DateTimeKind.Unspecified);
+        var utcDaBanca = BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dataHoraBrasilia);
+
+        var validator = new AgendarBancaDtoValidator(
+            new FixedTimeProvider(new DateTimeOffset(utcDaBanca, TimeSpan.Zero)));
+
+        var result = validator.Validate(DtoComData(dataHoraBrasilia));
+
+        Assert.False(result.IsValid);
+        Assert.Equal(nameof(AgendarBancaDto.DataHora), Assert.Single(result.Errors).PropertyName);
+    }
+
+    [Fact]
+    public void DataUmSegundoNoPassado_DeveSerInvalida()
+    {
+        var dataHoraBrasilia = new DateTime(2026, 6, 15, 10, 0, 0, DateTimeKind.Unspecified);
+        var utcDaBanca = BrasiliaTimeZoneService.ConverterDeBrasiliaParaUtc(dataHoraBrasilia);
+
+        var agoraUmSegundoDepois = new DateTimeOffset(utcDaBanca.AddSeconds(1), TimeSpan.Zero);
+        var validator = new AgendarBancaDtoValidator(new FixedTimeProvider(agoraUmSegundoDepois));
+
+        var result = validator.Validate(DtoComData(dataHoraBrasilia));
+
+        Assert.False(result.IsValid);
+    }
+}

--- a/TccManager.Tests/Validators/CapacidadeProfessorDtoValidatorTests.cs
+++ b/TccManager.Tests/Validators/CapacidadeProfessorDtoValidatorTests.cs
@@ -1,0 +1,43 @@
+using TccManager.Api.Validators;
+using TccManager.Shared.DTOs;
+using Xunit;
+
+namespace TccManager.Tests.Validators;
+
+public class CapacidadeProfessorDtoValidatorTests
+{
+    private const string MensagemEsperada = "O limite de orientandos deve estar entre 1 e 20.";
+
+    private readonly CapacidadeProfessorDtoValidator _validator = new();
+
+    private static CapacidadeProfessorDto DtoComLimite(int limite) => new()
+    {
+        LimiteOrientandos = limite,
+        AceitandoOrientandos = true
+    };
+
+    [Theory]
+    [InlineData(1)]   // limite inferior inclusivo
+    [InlineData(10)]
+    [InlineData(20)]  // limite superior inclusivo
+    public void LimiteDentroDoIntervalo_DevePassar(int limite)
+    {
+        var result = _validator.Validate(DtoComLimite(limite));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(21)]
+    public void LimiteForaDoIntervalo_DeveFalhar_ComPropriedadeEMensagemCertas(int limite)
+    {
+        var result = _validator.Validate(DtoComLimite(limite));
+
+        Assert.False(result.IsValid);
+        var erro = Assert.Single(result.Errors);
+        Assert.Equal(nameof(CapacidadeProfessorDto.LimiteOrientandos), erro.PropertyName);
+        Assert.Equal(MensagemEsperada, erro.ErrorMessage);
+    }
+}

--- a/TccManager.Tests/Validators/FeedbackDtoValidatorTests.cs
+++ b/TccManager.Tests/Validators/FeedbackDtoValidatorTests.cs
@@ -1,0 +1,52 @@
+using TccManager.Api.Validators;
+using TccManager.Shared.DTOs;
+using Xunit;
+
+namespace TccManager.Tests.Validators;
+
+public class FeedbackDtoValidatorTests
+{
+    private const string MensagemEsperada = "A nota deve estar entre 0 e 10.";
+
+    private readonly FeedbackDtoValidator _validator = new();
+
+    private static FeedbackDto DtoComNota(decimal? nota) => new()
+    {
+        Feedback = "Bom trabalho.",
+        Nota = nota
+    };
+
+    [Fact]
+    public void NotaAusente_DevePassar()
+    {
+        // Nota é opcional (decimal?): quando null, nenhuma regra é aplicada.
+        var result = _validator.Validate(DtoComNota(null));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(0)]   // limite inferior inclusivo
+    [InlineData(5)]
+    [InlineData(10)]  // limite superior inclusivo
+    public void NotaDentroDoIntervalo_DevePassar(decimal nota)
+    {
+        var result = _validator.Validate(DtoComNota(nota));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(11)]
+    [InlineData(10.5)]
+    public void NotaForaDoIntervalo_DeveFalhar_ComPropriedadeEMensagemCertas(decimal nota)
+    {
+        var result = _validator.Validate(DtoComNota(nota));
+
+        Assert.False(result.IsValid);
+        var erro = Assert.Single(result.Errors);
+        Assert.Equal(nameof(FeedbackDto.Nota), erro.PropertyName);
+        Assert.Equal(MensagemEsperada, erro.ErrorMessage);
+    }
+}

--- a/TccManager.Tests/Validators/FixedTimeProvider.cs
+++ b/TccManager.Tests/Validators/FixedTimeProvider.cs
@@ -1,0 +1,16 @@
+namespace TccManager.Tests.Validators;
+
+/// <summary>
+/// TimeProvider determinístico para testes: sempre retorna o "agora" fixado no
+/// construtor, permitindo validar regras de data futura/passada sem depender do
+/// relógio real da máquina de teste. Usado no lugar do FakeTimeProvider do pacote
+/// Microsoft.Extensions.TimeProvider.Testing (não referenciado neste projeto).
+/// </summary>
+internal sealed class FixedTimeProvider : TimeProvider
+{
+    private readonly DateTimeOffset _utcNow;
+
+    public FixedTimeProvider(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+}


### PR DESCRIPTION
## Summary
Implementação da Fase 3 (Qualidade & Confiabilidade) da Matriz de Evolução, via esteira completa de agentes (requisitos → produto → arquitetura → dados → implementação → testes → segurança → QA).

- **feat: validações avançadas com FluentValidation na API (Q1)** — 2ª camada de validação na API (DataAnnotations mantidas para o Client), 5 validators: AgendarBancaDto (data futura, fuso de Brasília), FeedbackDto (0-10), CapacidadeProfessorDto (1-20), Acompanhamento/PropostaTcc (estrutura, sem regra nova). Formato de erro idêntico ao das DataAnnotations.
- **test: cobrir endpoint de envio de entrega (Q2)** — fecha gap de cobertura fora dos 5 cenários explícitos da Matriz: testes de integração para POST /api/tcc/entregas (RN03, status Aprovado, bloqueio de reenvio, extensão de arquivo). Os 5 cenários originais (RN03 aceite final, RN05 banca, aprovação/rejeição, duplo lançamento, TccId no agendamento) já estavam cobertos por correções anteriores.
- **feat: paginação nas listagens (Q3)** — PagedResult<T> genérico, 4 endpoints paginados (professores, membros-externos, entregas, propostas-pendentes do orientador), clamp silencioso de page/pageSize, navegação básica no Client. Corrige overflow de Int32 no cálculo do Skip para páginas muito grandes.
- **feat: abstração de storage (Q4)** — IStorageService/LocalStorageService (sem Azure, por decisão explícita — projeto local sem plano de deploy), migra os 2 pontos de upload (entregas, atas). Corrige de quebra o path traversal conhecido em RegistrarResultadoBanca e um path traversal latente introduzido pelo próprio DeleteAsync.

Cada item passou por revisão de segurança dedicada (OWASP Top 10); achados corrigidos estão documentados nos commits individuais. Achados de menor severidade fora do escopo original foram registrados como backlog (controle de acesso em downloads, validação de conteúdo de upload, rate limiting em listagens, etc.).

## Test plan
- [x] `dotnet build` sem erros
- [x] `dotnet test` — 184/184 testes passando
- [x] Smoke test manual via API contra banco local real (professores, membros-externos, dashboard do orientador, clamp de paginação)
- [x] Validar visualmente as telas afetadas no navegador (GestaoProfessores, AgendamentoBanca, dashboard do orientador/coordenador)

🤖 Generated with [Claude Code](https://claude.com/claude-code)