### PR TITLE
feat: N2 - PDF da ata de defesa e rascunho pre-defesa (QuestPDF)

### DIFF
--- a/TccManager.Api/Configuration/AppUrlsOptions.cs
+++ b/TccManager.Api/Configuration/AppUrlsOptions.cs
@@ -1,0 +1,12 @@
+namespace TccManager.Api.Configuration;
+
+/// <summary>
+/// URLs base usadas para montar links absolutos em e-mails (N2 Etapa 2): o link do
+/// rascunho com token para o membro externo (<c>PublicApiBaseUrl</c>) e o atalho de
+/// login para os avaliadores internos (<c>ClientBaseUrl</c>). Bindada da seção "App".
+/// </summary>
+public class AppUrlsOptions
+{
+    public string PublicApiBaseUrl { get; set; } = string.Empty;
+    public string ClientBaseUrl { get; set; } = string.Empty;
+}

--- a/TccManager.Api/Configuration/PdfSetup.cs
+++ b/TccManager.Api/Configuration/PdfSetup.cs
@@ -17,8 +17,10 @@ public static class PdfSetup
         QuestPDF.Settings.License = LicenseType.Community;
 
         services.Configure<AtaInstitucionalOptions>(configuration.GetSection("Ata"));
+        services.Configure<AppUrlsOptions>(configuration.GetSection("App"));
 
         services.AddScoped<IAtaPdfService, AtaPdfService>();
+        services.AddScoped<IRascunhoAtaTokenService, RascunhoAtaTokenService>();
 
         return services;
     }

--- a/TccManager.Api/Configuration/PdfSetup.cs
+++ b/TccManager.Api/Configuration/PdfSetup.cs
@@ -1,0 +1,25 @@
+using QuestPDF.Infrastructure;
+using TccManager.Api.Services.Pdf;
+
+namespace TccManager.Api.Configuration;
+
+/// <summary>
+/// Registro em DI do subsistema de geração de PDF da ata (N2 Etapa 1). Segue o mesmo
+/// padrão de extensão estática já usado em EmailSetup. Config lida da seção "Ata"
+/// (Instituicao, Curso) do appsettings.json.
+/// </summary>
+public static class PdfSetup
+{
+    public static IServiceCollection AddAtaPdf(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Licença Community do QuestPDF — gratuita para projetos acadêmicos/sem
+        // faturamento, confirmada em docs/requisitos/2026-07-13-pdf-ata-questpdf.md (RNF-01).
+        QuestPDF.Settings.License = LicenseType.Community;
+
+        services.Configure<AtaInstitucionalOptions>(configuration.GetSection("Ata"));
+
+        services.AddScoped<IAtaPdfService, AtaPdfService>();
+
+        return services;
+    }
+}

--- a/TccManager.Api/Configuration/RateLimitingSetup.cs
+++ b/TccManager.Api/Configuration/RateLimitingSetup.cs
@@ -5,19 +5,27 @@ using Microsoft.AspNetCore.RateLimiting;
 namespace TccManager.Api.Configuration;
 
 /// <summary>
-/// Política de rate limiting nomeada "login": FixedWindowLimiter, particionado por
-/// IP do cliente (Connection.RemoteIpAddress — ambiente é localhost-only, sem proxy
-/// reverso, portanto não há tratamento de ForwardedHeaders/X-Forwarded-For).
+/// Políticas de rate limiting nomeadas "login" e "rascunho-publico": ambas usam
+/// FixedWindowLimiter, particionado por IP do cliente (Connection.RemoteIpAddress —
+/// ambiente é localhost-only, sem proxy reverso, portanto não há tratamento de
+/// ForwardedHeaders/X-Forwarded-For) e o mesmo OnRejected (429 + Retry-After + log).
 /// </summary>
 public static class RateLimitingSetup
 {
     public const string LoginPolicyName = "login";
+    public const string RascunhoPublicoPolicyName = "rascunho-publico";
 
     public static IServiceCollection ConfigureRateLimiting(this IServiceCollection services, IConfiguration configuration)
     {
-        var permitLimit = configuration.GetValue<int?>("RateLimiting:Login:PermitLimit") ?? 5;
-        var windowSeconds = configuration.GetValue<int?>("RateLimiting:Login:WindowSeconds") ?? 60;
-        var queueLimit = configuration.GetValue<int?>("RateLimiting:Login:QueueLimit") ?? 0;
+        var loginPermitLimit = configuration.GetValue<int?>("RateLimiting:Login:PermitLimit") ?? 5;
+        var loginWindowSeconds = configuration.GetValue<int?>("RateLimiting:Login:WindowSeconds") ?? 60;
+        var loginQueueLimit = configuration.GetValue<int?>("RateLimiting:Login:QueueLimit") ?? 0;
+
+        // O membro externo pode legitimamente recarregar/reabrir o link do rascunho
+        // (RF-04/RF-05) — janela um pouco mais folgada que a de "login".
+        var rascunhoPermitLimit = configuration.GetValue<int?>("RateLimiting:RascunhoPublico:PermitLimit") ?? 20;
+        var rascunhoWindowSeconds = configuration.GetValue<int?>("RateLimiting:RascunhoPublico:WindowSeconds") ?? 60;
+        var rascunhoQueueLimit = configuration.GetValue<int?>("RateLimiting:RascunhoPublico:QueueLimit") ?? 0;
 
         services.AddRateLimiter(options =>
         {
@@ -28,9 +36,19 @@ public static class RateLimitingSetup
                     partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
                     factory: _ => new FixedWindowRateLimiterOptions
                     {
-                        PermitLimit = permitLimit,
-                        Window = TimeSpan.FromSeconds(windowSeconds),
-                        QueueLimit = queueLimit
+                        PermitLimit = loginPermitLimit,
+                        Window = TimeSpan.FromSeconds(loginWindowSeconds),
+                        QueueLimit = loginQueueLimit
+                    }));
+
+            options.AddPolicy(RascunhoPublicoPolicyName, context =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = rascunhoPermitLimit,
+                        Window = TimeSpan.FromSeconds(rascunhoWindowSeconds),
+                        QueueLimit = rascunhoQueueLimit
                     }));
 
             options.OnRejected = (context, cancellationToken) =>
@@ -52,14 +70,29 @@ public static class RateLimitingSetup
                     .CreateLogger("TccManager.Api.RateLimiting");
 
                 logger.LogWarning(
-                    "Tentativa de login bloqueada por rate limiting. IP de origem: {RemoteIp}, Rota: {RequestPath}",
+                    "Requisição bloqueada por rate limiting. IP de origem: {RemoteIp}, Rota: {RequestPath}",
                     remoteIp,
-                    httpContext.Request.Path.Value);
+                    RedigirPath(httpContext.Request.Path.Value));
 
                 return ValueTask.CompletedTask;
             };
         });
 
         return services;
+    }
+
+    // O path de /api/rascunho-ata/{token} carrega a credencial de portador no próprio
+    // path — nunca deve chegar ao log em claro (rota pública, sem outra forma de logar
+    // apenas o template da rota a partir do rate limiter).
+    private const string RascunhoAtaPathPrefix = "/api/rascunho-ata/";
+
+    private static string RedigirPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return "unknown";
+
+        return path.StartsWith(RascunhoAtaPathPrefix, StringComparison.OrdinalIgnoreCase)
+            ? $"{RascunhoAtaPathPrefix}[REDACTED]"
+            : path;
     }
 }

--- a/TccManager.Api/Controllers/AvaliadorController.cs
+++ b/TccManager.Api/Controllers/AvaliadorController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TccManager.Api.Data;
+using TccManager.Api.Services.Pdf;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
 
@@ -14,10 +15,12 @@ namespace TccManager.Api.Controllers;
 public class AvaliadorController : ControllerBase
 {
     private readonly AppDbContext _context;
+    private readonly IAtaPdfService _ataPdfService;
 
-    public AvaliadorController(AppDbContext context)
+    public AvaliadorController(AppDbContext context, IAtaPdfService ataPdfService)
     {
         _context = context;
+        _ataPdfService = ataPdfService;
     }
 
     [HttpGet("meus-convites")]
@@ -52,5 +55,35 @@ public class AvaliadorController : ControllerBase
             .ToListAsync();
 
         return Ok(convites);
+    }
+
+    /// <summary>
+    /// RF-03/RNF-01 (Etapa 2): download do PDF rascunho para o avaliador interno.
+    /// Valida explicitamente o vínculo BancaAvaliador.ProfessorId == usuário autenticado
+    /// para a idBanca pedida — sem essa checagem, qualquer professor (inclusive o
+    /// orientador, que não deve ter acesso — decisão 6) conseguiria baixar o rascunho de
+    /// qualquer banca apenas trocando o idBanca na URL.
+    /// </summary>
+    [HttpGet("banca/{idBanca}/ata-rascunho-pdf")]
+    public async Task<IActionResult> GetAtaRascunhoPdf(int idBanca)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out int profId))
+            return Unauthorized();
+
+        var ehAvaliadorDaBanca = await _context.BancaAvaliadores
+            .AnyAsync(ba => ba.BancaId == idBanca && ba.ProfessorId == profId);
+
+        if (!ehAvaliadorDaBanca)
+            return Forbid();
+
+        var resultado = await _ataPdfService.GerarAtaRascunhoAsync(idBanca);
+
+        return resultado.Status switch
+        {
+            AtaPdfResultadoStatus.BancaNaoEncontrada => NotFound("Banca não encontrada."),
+            AtaPdfResultadoStatus.ResultadoJaRegistrado => StatusCode(StatusCodes.Status410Gone, "O resultado desta banca já foi registrado. Utilize o PDF final."),
+            _ => File(resultado.PdfBytes!, "application/pdf", $"ata-rascunho-{idBanca}.pdf")
+        };
     }
 }

--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -23,15 +23,23 @@ public class CoordenadorController : ControllerBase
     private readonly ITccNotificationService _notificationService;
     private readonly IStorageService _storageService;
     private readonly IAtaPdfService _ataPdfService;
+    private readonly IRascunhoAtaTokenService _rascunhoTokenService;
     private const decimal notaMinimaAprovacao = 60.0m;
 
-    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService, IStorageService storageService, IAtaPdfService ataPdfService)
+    public CoordenadorController(
+        AppDbContext context,
+        ISanitizerService sanitizerService,
+        ITccNotificationService notificationService,
+        IStorageService storageService,
+        IAtaPdfService ataPdfService,
+        IRascunhoAtaTokenService rascunhoTokenService)
     {
         _context = context;
         _sanitizerService = sanitizerService;
         _notificationService = notificationService;
         _storageService = storageService;
         _ataPdfService = ataPdfService;
+        _rascunhoTokenService = rascunhoTokenService;
     }
 
     [HttpGet("dashboard-stats")]
@@ -239,6 +247,8 @@ public class CoordenadorController : ControllerBase
         var bancas = await _context.Banca
             .Include(b => b.Tcc)
                 .ThenInclude(t => t.Aluno)
+            .Include(b => b.Avaliadores)
+                .ThenInclude(a => a.MembroExterno)
             .Where(b => b.Tcc!.Status == StatusTcc.AguardandoDefesa && b.NotaFinal == null)
             .Select(b => new BancaPendenteDto
             {
@@ -246,7 +256,17 @@ public class CoordenadorController : ControllerBase
                 DataHora = b.DataHora,
                 Local = b.Local,
                 TccTitulo = b.Tcc.Titulo,
-                NomeAluno = b.Tcc.Aluno!.Nome
+                NomeAluno = b.Tcc.Aluno!.Nome,
+                // Necessário para o botão de reenvio de token do rascunho (RF-06), um por
+                // membro externo — ver docs/arquitetura/2026-07-13-pdf-ata-rascunho-etapa2.md, seção 9.2.
+                MembrosExternos = b.Avaliadores
+                    .Where(a => a.MembroExternoId != null)
+                    .Select(a => new MembroExternoBancaDto
+                    {
+                        MembroExternoId = a.MembroExternoId!.Value,
+                        Nome = a.MembroExterno!.Nome
+                    })
+                    .ToList()
             })
             .ToListAsync();
         return Ok(bancas);
@@ -315,6 +335,43 @@ public class CoordenadorController : ControllerBase
             AtaPdfResultadoStatus.ResultadoNaoRegistrado => Conflict("O resultado desta banca ainda não foi registrado. Gere a ata após registrar a nota final."),
             _ => File(resultado.PdfBytes!, "application/pdf", $"ata-defesa-{idBanca}.pdf")
         };
+    }
+
+    [HttpGet("banca/{idBanca}/ata-rascunho-pdf")]
+    public async Task<IActionResult> GetAtaRascunhoPdf(int idBanca)
+    {
+        var resultado = await _ataPdfService.GerarAtaRascunhoAsync(idBanca);
+
+        return resultado.Status switch
+        {
+            AtaPdfResultadoStatus.BancaNaoEncontrada => NotFound("Banca não encontrada."),
+            AtaPdfResultadoStatus.ResultadoJaRegistrado => StatusCode(StatusCodes.Status410Gone, "O resultado desta banca já foi registrado. Utilize o PDF final."),
+            _ => File(resultado.PdfBytes!, "application/pdf", $"ata-rascunho-{idBanca}.pdf")
+        };
+    }
+
+    /// <summary>
+    /// RF-06: revoga o token vigente do membro externo para a banca e gera/envia um novo
+    /// (caso do e-mail perdido/não entregue — ver docs/requisitos, RF-06).
+    /// </summary>
+    [HttpPost("banca/{idBanca}/membro-externo/{idMembroExterno}/reenviar-rascunho")]
+    public async Task<IActionResult> ReenviarRascunhoAta(int idBanca, int idMembroExterno)
+    {
+        var vinculo = await _context.BancaAvaliadores
+            .Include(ba => ba.Banca)
+            .FirstOrDefaultAsync(ba => ba.BancaId == idBanca && ba.MembroExternoId == idMembroExterno);
+
+        if (vinculo?.Banca == null)
+            return NotFound("Este membro externo não é avaliador da banca informada.");
+
+        if (vinculo.Banca.NotaFinal != null)
+            return StatusCode(StatusCodes.Status410Gone, "O resultado desta banca já foi registrado; não é possível reenviar o rascunho.");
+
+        var tokenBruto = await _rascunhoTokenService.GerarTokenAsync(idBanca, idMembroExterno);
+
+        await _notificationService.NotificarReenvioRascunhoAsync(idBanca, idMembroExterno, tokenBruto);
+
+        return Ok("Novo link de acesso ao rascunho enviado com sucesso.");
     }
 
     [HttpGet("bancas-concluidas")]

--- a/TccManager.Api/Controllers/CoordenadorController.cs
+++ b/TccManager.Api/Controllers/CoordenadorController.cs
@@ -5,6 +5,7 @@ using TccManager.Api.Data;
 using TccManager.Api.Extensions;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Notifications;
+using TccManager.Api.Services.Pdf;
 using TccManager.Api.Services.Storage;
 using TccManager.Shared.DTOs;
 using TccManager.Shared.Enums;
@@ -21,14 +22,16 @@ public class CoordenadorController : ControllerBase
     private readonly ISanitizerService _sanitizerService;
     private readonly ITccNotificationService _notificationService;
     private readonly IStorageService _storageService;
+    private readonly IAtaPdfService _ataPdfService;
     private const decimal notaMinimaAprovacao = 60.0m;
 
-    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService, IStorageService storageService)
+    public CoordenadorController(AppDbContext context, ISanitizerService sanitizerService, ITccNotificationService notificationService, IStorageService storageService, IAtaPdfService ataPdfService)
     {
         _context = context;
         _sanitizerService = sanitizerService;
         _notificationService = notificationService;
         _storageService = storageService;
+        _ataPdfService = ataPdfService;
     }
 
     [HttpGet("dashboard-stats")]
@@ -136,6 +139,9 @@ public class CoordenadorController : ControllerBase
     [HttpPost("membros-externos")]
     public async Task<IActionResult> AdicionarMembroExterno([FromBody] MembroExterno membro)
     {
+        membro.Nome = _sanitizerService.Sanitizar(membro.Nome)!;
+        membro.Instituicao = _sanitizerService.Sanitizar(membro.Instituicao)!;
+
         _context.MembrosExternos.Add(membro);
         await _context.SaveChangesAsync();
         return Ok(membro);
@@ -149,9 +155,9 @@ public class CoordenadorController : ControllerBase
         if (membro == null)
             return NotFound("Membro externo não encontrado");
 
-        membro.Nome = dto.Nome;
+        membro.Nome = _sanitizerService.Sanitizar(dto.Nome)!;
         membro.Email = dto.Email;
-        membro.Instituicao = dto.Instituicao;
+        membro.Instituicao = _sanitizerService.Sanitizar(dto.Instituicao)!;
 
         await _context.SaveChangesAsync();
 
@@ -296,5 +302,41 @@ public class CoordenadorController : ControllerBase
             : "Resultado da banca registrado. O TCC foi reprovado conforme a nota informada.";
 
         return Ok(mensagem);
+    }
+
+    [HttpGet("banca/{idBanca}/ata-pdf")]
+    public async Task<IActionResult> GetAtaPdf(int idBanca)
+    {
+        var resultado = await _ataPdfService.GerarAtaFinalAsync(idBanca);
+
+        return resultado.Status switch
+        {
+            AtaPdfResultadoStatus.BancaNaoEncontrada => NotFound("Banca não encontrada."),
+            AtaPdfResultadoStatus.ResultadoNaoRegistrado => Conflict("O resultado desta banca ainda não foi registrado. Gere a ata após registrar a nota final."),
+            _ => File(resultado.PdfBytes!, "application/pdf", $"ata-defesa-{idBanca}.pdf")
+        };
+    }
+
+    [HttpGet("bancas-concluidas")]
+    public async Task<IActionResult> GetBancasConcluidas([FromQuery] PaginacaoQuery paginacao)
+    {
+        var bancas = await _context.Banca
+            .Where(b => b.NotaFinal != null)
+            .OrderByDescending(b => b.DataHora)
+            .Select(b => new BancaConcluidaDto
+            {
+                BancaId = b.Id,
+                TccTitulo = b.Tcc!.Titulo,
+                NomeAluno = b.Tcc.Aluno!.Nome,
+                DataHora = b.DataHora,
+                NotaFinal = b.NotaFinal!.Value,
+                // Aprovado deriva do Status já persistido (fonte de verdade histórica da
+                // decisão tomada em RegistrarResultadoBanca), não recomputado a partir da
+                // nota — ver docs/dados/2026-07-13-pdf-ata-questpdf.md, seção 5.
+                Aprovado = b.Tcc.Status == StatusTcc.Finalizado
+            })
+            .ToPagedResultAsync(paginacao);
+
+        return Ok(bancas);
     }
 }

--- a/TccManager.Api/Controllers/RascunhoAtaController.cs
+++ b/TccManager.Api/Controllers/RascunhoAtaController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using TccManager.Api.Configuration;
+using TccManager.Api.Services.Pdf;
+
+namespace TccManager.Api.Controllers;
+
+/// <summary>
+/// Endpoint público (RF-04/Etapa 2): acesso do avaliador externo ao PDF rascunho via
+/// token opaco, sem exigir cadastro/login (<c>MembroExterno</c> não tem conta no sistema).
+/// Classe inteira sem <see cref="AuthorizeAttribute"/> — o token é o único fator de acesso.
+/// </summary>
+[ApiController]
+[Route("api/rascunho-ata")]
+[AllowAnonymous]
+public class RascunhoAtaController : ControllerBase
+{
+    private readonly IRascunhoAtaTokenService _tokenService;
+    private readonly IAtaPdfService _ataPdfService;
+
+    public RascunhoAtaController(IRascunhoAtaTokenService tokenService, IAtaPdfService ataPdfService)
+    {
+        _tokenService = tokenService;
+        _ataPdfService = ataPdfService;
+    }
+
+    [HttpGet("{token}")]
+    [EnableRateLimiting(RateLimitingSetup.RascunhoPublicoPolicyName)]
+    public async Task<IActionResult> GetRascunhoPorToken(string token)
+    {
+        var validacao = await _tokenService.ValidarAsync(token);
+
+        if (validacao.Status == RascunhoTokenValidacaoStatus.Invalido)
+            return NotFound("Link inválido ou expirado.");
+
+        if (validacao.Status == RascunhoTokenValidacaoStatus.ResultadoRegistrado)
+            return StatusCode(StatusCodes.Status410Gone, "O resultado desta banca já foi registrado; o rascunho não está mais disponível.");
+
+        var resultado = await _ataPdfService.GerarAtaRascunhoAsync(validacao.BancaId);
+
+        // Servido inline (sem Content-Disposition: attachment) — o membro externo abre
+        // o PDF direto no navegador a partir do link recebido por e-mail (RF-07).
+        return resultado.Status switch
+        {
+            AtaPdfResultadoStatus.Sucesso => File(resultado.PdfBytes!, "application/pdf"),
+            AtaPdfResultadoStatus.ResultadoJaRegistrado => StatusCode(StatusCodes.Status410Gone, "O resultado desta banca já foi registrado; o rascunho não está mais disponível."),
+            _ => NotFound("Link inválido ou expirado.")
+        };
+    }
+}

--- a/TccManager.Api/Data/AppDbContext.cs
+++ b/TccManager.Api/Data/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext : DbContext
     public DbSet<BancaAvaliador> BancaAvaliadores { get; set; }
     public DbSet<MembroExterno> MembrosExternos { get; set; }
     public DbSet<RefreshToken> RefreshTokens { get; set; }
+    public DbSet<RascunhoAtaToken> RascunhoAtaTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -48,6 +49,34 @@ public class AppDbContext : DbContext
                 .WithMany()
                 .HasForeignKey(rt => rt.UsuarioId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<RascunhoAtaToken>(entity =>
+        {
+            entity.ToTable("rascunho_ata_tokens");
+
+            entity.Property(t => t.TokenHash)
+                .HasColumnType("char(64)")
+                .IsRequired();
+
+            entity.HasIndex(t => t.TokenHash).IsUnique();
+
+            // Reforça no banco a invariante "no máximo 1 token ativo por par" — ver
+            // docs/dados/2026-07-13-pdf-ata-rascunho-etapa2.md, seção 3.1.
+            entity.HasIndex(t => new { t.BancaId, t.MembroExternoId })
+                .IsUnique()
+                .HasFilter("[RevokedAtUtc] IS NULL")
+                .HasDatabaseName("UX_rascunho_ata_tokens_Banca_Membro_Ativo");
+
+            entity.HasOne(t => t.Banca)
+                .WithMany()
+                .HasForeignKey(t => t.BancaId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(t => t.MembroExterno)
+                .WithMany()
+                .HasForeignKey(t => t.MembroExternoId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/TccManager.Api/Migrations/20260713235122_AddRascunhoAtaTokens.Designer.cs
+++ b/TccManager.Api/Migrations/20260713235122_AddRascunhoAtaTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TccManager.Api.Data;
 
@@ -11,9 +12,11 @@ using TccManager.Api.Data;
 namespace TccManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713235122_AddRascunhoAtaTokens")]
+    partial class AddRascunhoAtaTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TccManager.Api/Migrations/20260713235122_AddRascunhoAtaTokens.cs
+++ b/TccManager.Api/Migrations/20260713235122_AddRascunhoAtaTokens.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TccManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRascunhoAtaTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "rascunho_ata_tokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BancaId = table.Column<int>(type: "int", nullable: false),
+                    MembroExternoId = table.Column<int>(type: "int", nullable: false),
+                    TokenHash = table.Column<string>(type: "char(64)", maxLength: 64, nullable: false),
+                    ExpiresAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RevokedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_rascunho_ata_tokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_rascunho_ata_tokens_Banca_BancaId",
+                        column: x => x.BancaId,
+                        principalTable: "Banca",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_rascunho_ata_tokens_MembrosExternos_MembroExternoId",
+                        column: x => x.MembroExternoId,
+                        principalTable: "MembrosExternos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_rascunho_ata_tokens_MembroExternoId",
+                table: "rascunho_ata_tokens",
+                column: "MembroExternoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_rascunho_ata_tokens_TokenHash",
+                table: "rascunho_ata_tokens",
+                column: "TokenHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_rascunho_ata_tokens_Banca_Membro_Ativo",
+                table: "rascunho_ata_tokens",
+                columns: new[] { "BancaId", "MembroExternoId" },
+                unique: true,
+                filter: "[RevokedAtUtc] IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "rascunho_ata_tokens");
+        }
+    }
+}

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -101,7 +101,20 @@ try
 
     app.UseMiddleware<CorrelationIdMiddleware>();
 
-    app.UseSerilogRequestLogging();
+    // MessageTemplate customizado para não expor o token bruto do rascunho no path
+    // quando essa rota lançar exceção (nível Error, acima do MinimumLevel.Default).
+    app.UseSerilogRequestLogging(options =>
+    {
+        options.MessageTemplate = "HTTP {RequestMethod} {RequestPathRedacted} responded {StatusCode} in {Elapsed:0.0000} ms";
+        options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+        {
+            var path = httpContext.Request.Path.Value ?? string.Empty;
+            var redigido = path.StartsWith("/api/rascunho-ata/", StringComparison.OrdinalIgnoreCase)
+                ? "/api/rascunho-ata/[REDACTED]"
+                : path;
+            diagnosticContext.Set("RequestPathRedacted", redigido);
+        };
+    });
 
     app.UseHttpsRedirection();
 

--- a/TccManager.Api/Program.cs
+++ b/TccManager.Api/Program.cs
@@ -85,6 +85,7 @@ try
     builder.Services.AddScoped<IAuthTokenService, AuthTokenService>();
 
     builder.Services.AddEmailNotifications(builder.Configuration);
+    builder.Services.AddAtaPdf(builder.Configuration);
 
     var app = builder.Build();
 

--- a/TccManager.Api/Resources/EmailTemplates/banca-agendada.html
+++ b/TccManager.Api/Resources/EmailTemplates/banca-agendada.html
@@ -15,6 +15,7 @@
       {{ListaMembrosBanca}}
     </ul>
     <p>Caso você seja um membro externo convidado, esta mensagem serve como convite formal para participar da defesa.</p>
+    {{BlocoAcessoRascunho}}
     <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
     <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
   </div>

--- a/TccManager.Api/Resources/EmailTemplates/rascunho-reenviado.html
+++ b/TccManager.Api/Resources/EmailTemplates/rascunho-reenviado.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Novo link de acesso ao rascunho da ata</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #222; background-color: #f4f4f4; padding: 24px;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 24px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #1565c0;">Novo link de acesso ao rascunho da ata</h2>
+    <p>Olá, {{NomeMembro}}.</p>
+    <p>O link anterior de acesso ao rascunho da ata da defesa em que você é avaliador(a) foi substituído por um novo, conforme solicitado.</p>
+    <p><a href="{{LinkRascunho}}">Acessar rascunho da ata</a></p>
+    <p>O link anterior não é mais válido.</p>
+    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 24px 0;">
+    <p style="font-size: 12px; color: #888;">Esta é uma mensagem automática do SIGA-TCC. Não responda a este e-mail.</p>
+  </div>
+</body>
+</html>

--- a/TccManager.Api/Services/Notifications/ITccNotificationService.cs
+++ b/TccManager.Api/Services/Notifications/ITccNotificationService.cs
@@ -30,4 +30,12 @@ public interface ITccNotificationService
     /// o template (resultado-aprovado vs. resultado-reprovado).
     /// </summary>
     Task NotificarResultadoBancaAsync(int bancaId, bool aprovado);
+
+    /// <summary>
+    /// Reenvio de token de acesso ao rascunho (RF-06/Etapa 2) — dispara um e-mail
+    /// dedicado para o <c>MembroExterno</c> com o novo link (<paramref name="tokenBruto"/>
+    /// já gerado pelo chamador via <c>IRascunhoAtaTokenService.GerarTokenAsync</c>, que
+    /// já revogou o token anterior do par).
+    /// </summary>
+    Task NotificarReenvioRascunhoAsync(int bancaId, int membroExternoId, string tokenBruto);
 }

--- a/TccManager.Api/Services/Notifications/TccNotificationService.cs
+++ b/TccManager.Api/Services/Notifications/TccNotificationService.cs
@@ -1,8 +1,11 @@
 using System.Net;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using TccManager.Api.Configuration;
 using TccManager.Api.Data;
 using TccManager.Api.Services;
 using TccManager.Api.Services.Email;
+using TccManager.Api.Services.Pdf;
 using TccManager.Shared.Enums;
 
 namespace TccManager.Api.Services.Notifications;
@@ -20,17 +23,30 @@ public class TccNotificationService : ITccNotificationService
     private readonly IEmailTemplateRenderer _renderer;
     private readonly IEmailQueue _queue;
     private readonly ILogger<TccNotificationService> _logger;
+    private readonly IRascunhoAtaTokenService _rascunhoTokenService;
+    private readonly AppUrlsOptions _appUrls;
+
+    /// <summary>
+    /// Bloco de acesso ao rascunho renderizado quando não há link a oferecer (aluno e
+    /// orientador não têm acesso ao rascunho — decisão 6/Etapa 2): apenas informativo.
+    /// </summary>
+    private const string BlocoAcessoIndisponivel =
+        "<p style=\"color:#666; font-size: 13px;\">Esta mensagem é apenas informativa; o rascunho da ata fica disponível somente para o Coordenador e os avaliadores da banca.</p>";
 
     public TccNotificationService(
         AppDbContext context,
         IEmailTemplateRenderer renderer,
         IEmailQueue queue,
-        ILogger<TccNotificationService> logger)
+        ILogger<TccNotificationService> logger,
+        IRascunhoAtaTokenService rascunhoTokenService,
+        IOptions<AppUrlsOptions> appUrls)
     {
         _context = context;
         _renderer = renderer;
         _queue = queue;
         _logger = logger;
+        _rascunhoTokenService = rascunhoTokenService;
+        _appUrls = appUrls.Value;
     }
 
     public async Task NotificarPropostaAprovadaAsync(int tccId)
@@ -115,25 +131,59 @@ public class TccNotificationService : ITccNotificationService
                 return;
             }
 
-            var candidatos = new List<(string Papel, string? Email)>
-            {
-                ("Aluno", banca.Tcc.Aluno?.Email),
-                ("Orientador", banca.Tcc.Orientador?.Email)
-            };
-
             var nomesAvaliadores = new List<string>();
+
+            // Aluno e Orientador não têm acesso ao rascunho (decisão 6/Etapa 2) — recebem
+            // apenas o bloco informativo, sem link.
+            var envios = new List<(string Email, string BlocoAcesso)>();
+
+            void AdicionarSemAcesso(string? email)
+            {
+                if (!string.IsNullOrWhiteSpace(email))
+                    envios.Add((email, BlocoAcessoIndisponivel));
+            }
+
+            AdicionarSemAcesso(banca.Tcc.Aluno?.Email);
+            AdicionarSemAcesso(banca.Tcc.Orientador?.Email);
+
+            var linkAtalhoInterno = MontarLinkAtalhoInterno();
 
             foreach (var avaliador in banca.Avaliadores)
             {
                 if (avaliador.ProfessorId.HasValue && avaliador.Professor != null)
                 {
-                    candidatos.Add(($"Avaliador interno {avaliador.Professor.Nome}", avaliador.Professor.Email));
                     nomesAvaliadores.Add(avaliador.Professor.Nome);
+
+                    if (!string.IsNullOrWhiteSpace(avaliador.Professor.Email))
+                        envios.Add((avaliador.Professor.Email, BlocoAcessoInterno(linkAtalhoInterno)));
                 }
                 else if (avaliador.MembroExternoId.HasValue && avaliador.MembroExterno != null)
                 {
-                    candidatos.Add(($"Avaliador externo {avaliador.MembroExterno.Nome}", avaliador.MembroExterno.Email));
                     nomesAvaliadores.Add($"{avaliador.MembroExterno.Nome} ({avaliador.MembroExterno.Instituicao})");
+
+                    if (string.IsNullOrWhiteSpace(avaliador.MembroExterno.Email))
+                        continue;
+
+                    // Token gerado aqui dentro: o valor bruto nunca precisa cruzar
+                    // fronteiras de camada, vive só neste escopo até compor o link do
+                    // e-mail (ver docs/arquitetura/2026-07-13-pdf-ata-rascunho-etapa2.md, seção 7.1).
+                    try
+                    {
+                        var tokenBruto = await _rascunhoTokenService.GerarTokenAsync(bancaId, avaliador.MembroExternoId.Value);
+                        var link = MontarLinkRascunhoExterno(tokenBruto);
+                        envios.Add((avaliador.MembroExterno.Email, BlocoAcessoExterno(link)));
+                    }
+                    catch (Exception exToken)
+                    {
+                        // Defesa em profundidade: falha ao gerar o token de um membro não
+                        // deve impedir o e-mail informativo de banca agendada para ele nem
+                        // para os demais destinatários.
+                        _logger.LogWarning(
+                            exToken,
+                            "Falha ao gerar token de rascunho para MembroExterno {MembroExternoId} na Banca {BancaId}; e-mail será enviado sem link de acesso.",
+                            avaliador.MembroExternoId, bancaId);
+                        envios.Add((avaliador.MembroExterno.Email, BlocoAcessoIndisponivel));
+                    }
                 }
                 else
                 {
@@ -146,24 +196,40 @@ public class TccNotificationService : ITccNotificationService
                 }
             }
 
-            var destinatarios = ColetarEmails(candidatos.ToArray());
-            if (destinatarios.Count == 0) return;
+            // Distinct por e-mail (mantendo a primeira ocorrência) — mesmo espírito do
+            // ColetarEmails().Distinct() já usado nos demais eventos: evita duas mensagens
+            // para o mesmo endereço quando ele acumula mais de um papel (ex.: aluno e
+            // orientador com o mesmo e-mail cadastrado).
+            var enviosUnicos = envios
+                .GroupBy(e => e.Email)
+                .Select(g => g.First())
+                .ToList();
+
+            if (enviosUnicos.Count == 0)
+            {
+                _logger.LogWarning("Notificação 'Banca de TCC agendada' sem destinatários válidos; e-mail não enviado. Banca {BancaId}.", bancaId);
+                return;
+            }
 
             var dataHoraBrasilia = BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(banca.DataHora);
             var listaMembrosHtml = nomesAvaliadores.Count > 0
                 ? string.Concat(nomesAvaliadores.Select(n => $"<li>{WebUtility.HtmlEncode(n)}</li>"))
                 : "<li>Nenhum avaliador registrado</li>";
 
-            var corpo = _renderer.Render("banca-agendada", new Dictionary<string, string>
+            foreach (var (email, blocoAcesso) in enviosUnicos)
             {
-                ["NomeAluno"] = Codificar(banca.Tcc.Aluno?.Nome),
-                ["TituloTcc"] = Codificar(banca.Tcc.Titulo),
-                ["DataHora"] = dataHoraBrasilia.ToString("dd/MM/yyyy HH:mm"),
-                ["Local"] = Codificar(banca.Local),
-                ["ListaMembrosBanca"] = listaMembrosHtml
-            });
+                var corpo = _renderer.Render("banca-agendada", new Dictionary<string, string>
+                {
+                    ["NomeAluno"] = Codificar(banca.Tcc.Aluno?.Nome),
+                    ["TituloTcc"] = Codificar(banca.Tcc.Titulo),
+                    ["DataHora"] = dataHoraBrasilia.ToString("dd/MM/yyyy HH:mm"),
+                    ["Local"] = Codificar(banca.Local),
+                    ["ListaMembrosBanca"] = listaMembrosHtml,
+                    ["BlocoAcessoRascunho"] = blocoAcesso
+                });
 
-            Enfileirar(destinatarios, "Banca de TCC agendada", corpo);
+                Enfileirar(new List<string> { email }, "Banca de TCC agendada", corpo);
+            }
         }
         catch (Exception ex)
         {
@@ -291,6 +357,36 @@ public class TccNotificationService : ITccNotificationService
         }
     }
 
+    public async Task NotificarReenvioRascunhoAsync(int bancaId, int membroExternoId, string tokenBruto)
+    {
+        try
+        {
+            var membro = await _context.MembrosExternos.FirstOrDefaultAsync(m => m.Id == membroExternoId);
+
+            if (membro == null || string.IsNullOrWhiteSpace(membro.Email))
+            {
+                _logger.LogWarning(
+                    "NotificarReenvioRascunhoAsync: MembroExterno {MembroExternoId} não encontrado ou sem e-mail válido (Banca {BancaId}).",
+                    membroExternoId, bancaId);
+                return;
+            }
+
+            var link = MontarLinkRascunhoExterno(tokenBruto);
+
+            var corpo = _renderer.Render("rascunho-reenviado", new Dictionary<string, string>
+            {
+                ["NomeMembro"] = Codificar(membro.Nome),
+                ["LinkRascunho"] = WebUtility.HtmlEncode(link)
+            });
+
+            Enfileirar(new List<string> { membro.Email }, "Novo link de acesso ao rascunho da ata", corpo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao preparar notificação de reenvio de rascunho para Banca {BancaId}, MembroExterno {MembroExternoId}.", bancaId, membroExternoId);
+        }
+    }
+
     private async Task<IEnumerable<(string Papel, string? Email)>> ObterCandidatosCoordenadoresAsync()
     {
         var coordenadores = await _context.Usuarios
@@ -300,6 +396,18 @@ public class TccNotificationService : ITccNotificationService
 
         return coordenadores.Select(c => ($"Coordenador {c.Nome}", (string?)c.Email));
     }
+
+    private string MontarLinkRascunhoExterno(string tokenBruto) =>
+        $"{_appUrls.PublicApiBaseUrl?.TrimEnd('/')}/api/rascunho-ata/{tokenBruto}";
+
+    private string MontarLinkAtalhoInterno() =>
+        $"{_appUrls.ClientBaseUrl?.TrimEnd('/')}/avaliador/convites";
+
+    private static string BlocoAcessoExterno(string link) =>
+        $"<p><a href=\"{WebUtility.HtmlEncode(link)}\">Acessar rascunho da ata</a></p>";
+
+    private static string BlocoAcessoInterno(string link) =>
+        $"<p><a href=\"{WebUtility.HtmlEncode(link)}\">Acessar no sistema</a> (é necessário estar logado).</p>";
 
     /// <summary>
     /// Filtra candidatos com e-mail vazio/nulo, logando um aviso individual por

--- a/TccManager.Api/Services/Pdf/AtaInstitucionalOptions.cs
+++ b/TccManager.Api/Services/Pdf/AtaInstitucionalOptions.cs
@@ -1,0 +1,12 @@
+namespace TccManager.Api.Services.Pdf;
+
+/// <summary>
+/// Options bindadas da seção "Ata" da configuração. Cabeçalho institucional exibido no
+/// PDF da ata (RF-06) — nunca hardcoded no template. Logo/imagem fica fora de escopo
+/// nesta etapa (ver docs/arquitetura/2026-07-13-pdf-ata-questpdf.md, seção 6).
+/// </summary>
+public class AtaInstitucionalOptions
+{
+    public string Instituicao { get; set; } = string.Empty;
+    public string Curso { get; set; } = string.Empty;
+}

--- a/TccManager.Api/Services/Pdf/AtaPdfDocument.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfDocument.cs
@@ -52,6 +52,15 @@ public class AtaPdfDocument : IDocument
 
             column.Item().AlignCenter().Text("Ata de Defesa de Trabalho de Conclusão de Curso").Bold().FontSize(13);
 
+            if (_model.Rascunho)
+            {
+                // Identificação visual do rascunho (RNF-05): texto simples, sem marca
+                // d'água — decisão técnica fechada em docs/requisitos/2026-07-13-pdf-ata-rascunho-etapa2.md.
+                column.Item().PaddingTop(4).AlignCenter()
+                    .Text("RASCUNHO — documento preliminar, sujeito a alteração")
+                    .Bold().FontSize(10).FontColor(Colors.Red.Darken2);
+            }
+
             column.Item().PaddingTop(8).BorderBottom(1).BorderColor(Colors.Grey.Lighten1);
         });
     }
@@ -65,8 +74,14 @@ public class AtaPdfDocument : IDocument
             column.Item().Element(ComposeDadosTcc);
             column.Item().Element(ComposeComposicaoBanca);
             column.Item().Element(ComposeDefesa);
-            column.Item().Element(ComposeResultado);
-            column.Item().PaddingTop(30).Element(ComposeAssinaturas);
+
+            // Rascunho (Etapa 2): sem nota/motivo (RF-01) e sem seção de assinaturas
+            // (decisão 7 — omitida por completo, nem em branco).
+            if (!_model.Rascunho)
+            {
+                column.Item().Element(ComposeResultado);
+                column.Item().PaddingTop(30).Element(ComposeAssinaturas);
+            }
         });
     }
 
@@ -152,7 +167,9 @@ public class AtaPdfDocument : IDocument
             column.Item().Text(text =>
             {
                 text.Span("Nota Final: ").SemiBold();
-                text.Span(_model.NotaFinal.ToString("0.0"));
+                // ComposeResultado só é chamado quando !Rascunho (ver ComposeConteudo), e
+                // nesse caminho o AtaPdfService só chega a Sucesso com NotaFinal != null.
+                text.Span(_model.NotaFinal!.Value.ToString("0.0"));
             });
 
             if (!string.IsNullOrWhiteSpace(_model.MotivoReprovacao))

--- a/TccManager.Api/Services/Pdf/AtaPdfDocument.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfDocument.cs
@@ -1,0 +1,200 @@
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace TccManager.Api.Services.Pdf;
+
+/// <summary>
+/// Layout do PDF final da ata de defesa (RF-02), implementado via <see cref="IDocument"/> do
+/// QuestPDF. Não conhece EF Core nem <c>AppDbContext</c> — recebe um <see cref="AtaPdfModel"/>
+/// já resolvido pelo <see cref="AtaPdfService"/>. Composição dividida em métodos privados
+/// nomeados por seção (cabeçalho, dados do TCC, composição da banca, defesa, resultado,
+/// assinaturas, rodapé), conforme docs/arquitetura/2026-07-13-pdf-ata-questpdf.md, seção 2.2.
+/// </summary>
+public class AtaPdfDocument : IDocument
+{
+    private readonly AtaPdfModel _model;
+
+    public AtaPdfDocument(AtaPdfModel model)
+    {
+        _model = model;
+    }
+
+    public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+
+    public DocumentSettings GetSettings() => DocumentSettings.Default;
+
+    public void Compose(IDocumentContainer container)
+    {
+        container.Page(page =>
+        {
+            page.Size(PageSizes.A4);
+            page.Margin(2, Unit.Centimetre);
+            page.DefaultTextStyle(x => x.FontSize(11));
+
+            page.Header().Element(ComposeCabecalho);
+            page.Content().Element(ComposeConteudo);
+            page.Footer().Element(ComposeRodape);
+        });
+    }
+
+    private void ComposeCabecalho(IContainer container)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(2);
+
+            if (!string.IsNullOrWhiteSpace(_model.Instituicao))
+                column.Item().AlignCenter().Text(_model.Instituicao).Bold().FontSize(14);
+
+            if (!string.IsNullOrWhiteSpace(_model.Curso))
+                column.Item().AlignCenter().Text(_model.Curso).FontSize(11);
+
+            column.Item().AlignCenter().Text("Ata de Defesa de Trabalho de Conclusão de Curso").Bold().FontSize(13);
+
+            column.Item().PaddingTop(8).BorderBottom(1).BorderColor(Colors.Grey.Lighten1);
+        });
+    }
+
+    private void ComposeConteudo(IContainer container)
+    {
+        container.PaddingTop(15).Column(column =>
+        {
+            column.Spacing(14);
+
+            column.Item().Element(ComposeDadosTcc);
+            column.Item().Element(ComposeComposicaoBanca);
+            column.Item().Element(ComposeDefesa);
+            column.Item().Element(ComposeResultado);
+            column.Item().PaddingTop(30).Element(ComposeAssinaturas);
+        });
+    }
+
+    private void ComposeDadosTcc(IContainer container)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(3);
+
+            column.Item().Text("Dados do Trabalho").Bold().FontSize(12);
+
+            column.Item().Text(text =>
+            {
+                text.Span("Aluno(a): ").SemiBold();
+                text.Span(_model.NomeAluno);
+            });
+
+            column.Item().Text(text =>
+            {
+                text.Span("Título: ").SemiBold();
+                text.Span(_model.TccTitulo);
+            });
+        });
+    }
+
+    private void ComposeComposicaoBanca(IContainer container)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(3);
+
+            column.Item().Text("Composição da Banca Examinadora").Bold().FontSize(12);
+
+            column.Item().Text(text =>
+            {
+                text.Span("Orientador(a): ").SemiBold();
+                text.Span(_model.NomeOrientador);
+            });
+
+            foreach (var avaliador in _model.Avaliadores)
+            {
+                column.Item().Text(text =>
+                {
+                    text.Span("Avaliador(a): ").SemiBold();
+                    text.Span(string.IsNullOrWhiteSpace(avaliador.Instituicao)
+                        ? avaliador.Nome
+                        : $"{avaliador.Nome} ({avaliador.Instituicao})");
+                });
+            }
+        });
+    }
+
+    private void ComposeDefesa(IContainer container)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(3);
+
+            column.Item().Text("Data e Local da Defesa").Bold().FontSize(12);
+
+            column.Item().Text(text =>
+            {
+                text.Span("Data/Hora: ").SemiBold();
+                text.Span(_model.DataHoraDefesaBrasilia.ToString("dd/MM/yyyy HH:mm") + " (horário de Brasília)");
+            });
+
+            column.Item().Text(text =>
+            {
+                text.Span("Local: ").SemiBold();
+                text.Span(_model.Local);
+            });
+        });
+    }
+
+    private void ComposeResultado(IContainer container)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(3);
+
+            column.Item().Text("Resultado").Bold().FontSize(12);
+
+            column.Item().Text(text =>
+            {
+                text.Span("Nota Final: ").SemiBold();
+                text.Span(_model.NotaFinal.ToString("0.0"));
+            });
+
+            if (!string.IsNullOrWhiteSpace(_model.MotivoReprovacao))
+            {
+                column.Item().PaddingTop(4).Text(text =>
+                {
+                    text.Span("Motivo da Reprovação: ").SemiBold();
+                    text.Span(_model.MotivoReprovacao);
+                });
+            }
+        });
+    }
+
+    private void ComposeAssinaturas(IContainer container)
+    {
+        container.Row(row =>
+        {
+            row.Spacing(20);
+
+            row.RelativeItem().Column(column =>
+            {
+                column.Item().PaddingTop(30).BorderTop(1).PaddingTop(3).AlignCenter().Text("Orientador(a)");
+            });
+
+            foreach (var _ in _model.Avaliadores)
+            {
+                row.RelativeItem().Column(column =>
+                {
+                    column.Item().PaddingTop(30).BorderTop(1).PaddingTop(3).AlignCenter().Text("Avaliador(a)");
+                });
+            }
+        });
+    }
+
+    private void ComposeRodape(IContainer container)
+    {
+        container.AlignCenter().Text(text =>
+        {
+            text.Span("Documento gerado automaticamente pelo sistema SIGA-TCC em ")
+                .FontSize(8).FontColor(Colors.Grey.Darken1);
+            text.Span(_model.DataGeracaoBrasilia.ToString("dd/MM/yyyy HH:mm") + " (horário de Brasília)")
+                .FontSize(8).FontColor(Colors.Grey.Darken1);
+        });
+    }
+}

--- a/TccManager.Api/Services/Pdf/AtaPdfModel.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfModel.cs
@@ -1,0 +1,27 @@
+namespace TccManager.Api.Services.Pdf;
+
+/// <summary>
+/// Um membro (avaliador) da banca já resolvido a partir do polimorfismo de
+/// <see cref="TccManager.Shared.Models.BancaAvaliador"/>: <c>Instituicao</c> é nulo/vazio
+/// para avaliadores internos (professores) e preenchido para membros externos.
+/// </summary>
+public record AtaMembroBancaModel(string Nome, string? Instituicao);
+
+/// <summary>
+/// View model interno da API para o template do PDF da ata (RF-02). Desacoplado dos
+/// models EF: não conhece <c>AppDbContext</c> nem navegações — toda a resolução do
+/// polimorfismo de <c>BancaAvaliador</c> e a conversão de fuso (Brasília) já vêm prontas.
+/// </summary>
+public record AtaPdfModel(
+    string Instituicao,
+    string Curso,
+    string TccTitulo,
+    string NomeAluno,
+    string NomeOrientador,
+    IReadOnlyList<AtaMembroBancaModel> Avaliadores,
+    DateTime DataHoraDefesaBrasilia,
+    string Local,
+    decimal NotaFinal,
+    string? MotivoReprovacao,
+    DateTime DataGeracaoBrasilia
+);

--- a/TccManager.Api/Services/Pdf/AtaPdfModel.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfModel.cs
@@ -8,9 +8,13 @@ namespace TccManager.Api.Services.Pdf;
 public record AtaMembroBancaModel(string Nome, string? Instituicao);
 
 /// <summary>
-/// View model interno da API para o template do PDF da ata (RF-02). Desacoplado dos
-/// models EF: não conhece <c>AppDbContext</c> nem navegações — toda a resolução do
-/// polimorfismo de <c>BancaAvaliador</c> e a conversão de fuso (Brasília) já vêm prontas.
+/// View model interno da API para o template do PDF da ata (RF-02/Etapa 1, RF-01/Etapa 2).
+/// Desacoplado dos models EF: não conhece <c>AppDbContext</c> nem navegações — toda a
+/// resolução do polimorfismo de <c>BancaAvaliador</c> e a conversão de fuso (Brasília) já
+/// vêm prontas. <c>Rascunho</c> ramifica o layout no <see cref="AtaPdfDocument"/>: quando
+/// <c>true</c>, <c>NotaFinal</c> e <c>MotivoReprovacao</c> vêm nulos (o resultado ainda não
+/// existe) e a seção de assinaturas é omitida por completo (ver
+/// docs/arquitetura/2026-07-13-pdf-ata-rascunho-etapa2.md, seção 4).
 /// </summary>
 public record AtaPdfModel(
     string Instituicao,
@@ -21,7 +25,8 @@ public record AtaPdfModel(
     IReadOnlyList<AtaMembroBancaModel> Avaliadores,
     DateTime DataHoraDefesaBrasilia,
     string Local,
-    decimal NotaFinal,
+    decimal? NotaFinal,
     string? MotivoReprovacao,
-    DateTime DataGeracaoBrasilia
+    DateTime DataGeracaoBrasilia,
+    bool Rascunho = false
 );

--- a/TccManager.Api/Services/Pdf/AtaPdfService.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfService.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QuestPDF.Fluent;
+using TccManager.Api.Data;
+using TccManager.Shared.Enums;
+
+namespace TccManager.Api.Services.Pdf;
+
+/// <summary>
+/// Orquestra a geração do PDF final da ata: carrega os dados via EF Core (única query,
+/// AsNoTracking — leitura pontual, ver docs/dados/2026-07-13-pdf-ata-questpdf.md), monta o
+/// <see cref="AtaPdfModel"/> resolvendo o polimorfismo de <c>BancaAvaliador</c> e a conversão
+/// de fuso, e delega o layout ao <see cref="AtaPdfDocument"/> (QuestPDF). Não conhece a
+/// fluent API do QuestPDF diretamente — apenas invoca <c>GeneratePdf()</c> sobre o documento.
+/// </summary>
+public class AtaPdfService : IAtaPdfService
+{
+    private readonly AppDbContext _context;
+    private readonly AtaInstitucionalOptions _options;
+
+    public AtaPdfService(AppDbContext context, IOptions<AtaInstitucionalOptions> options)
+    {
+        _context = context;
+        _options = options.Value;
+    }
+
+    public async Task<AtaPdfResultado> GerarAtaFinalAsync(int idBanca)
+    {
+        var banca = await _context.Banca
+            .AsNoTracking()
+            .Include(b => b.Tcc).ThenInclude(t => t!.Aluno)
+            .Include(b => b.Tcc).ThenInclude(t => t!.Orientador)
+            .Include(b => b.Avaliadores).ThenInclude(a => a.Professor)
+            .Include(b => b.Avaliadores).ThenInclude(a => a.MembroExterno)
+            .FirstOrDefaultAsync(b => b.Id == idBanca);
+
+        if (banca == null)
+            return new AtaPdfResultado { Status = AtaPdfResultadoStatus.BancaNaoEncontrada };
+
+        if (banca.NotaFinal == null)
+            return new AtaPdfResultado { Status = AtaPdfResultadoStatus.ResultadoNaoRegistrado };
+
+        var avaliadores = banca.Avaliadores
+            .Select(a => a.ProfessorId != null
+                ? new AtaMembroBancaModel(a.Professor!.Nome, null)
+                : new AtaMembroBancaModel(a.MembroExterno!.Nome, a.MembroExterno!.Instituicao))
+            .ToList();
+
+        // Motivo de reprovação (Tcc.MotivoRejeicao) só aparece quando a banca de fato
+        // reprovou o TCC — derivado do Status já persistido (fonte de verdade histórica),
+        // e não recomputado a partir da nota (ver docs/dados/2026-07-13-pdf-ata-questpdf.md, seção 5).
+        var motivoReprovacao = banca.Tcc!.Status == StatusTcc.Reprovado
+            ? banca.Tcc.MotivoRejeicao
+            : null;
+
+        var model = new AtaPdfModel(
+            Instituicao: _options.Instituicao,
+            Curso: _options.Curso,
+            TccTitulo: banca.Tcc.Titulo,
+            NomeAluno: banca.Tcc.Aluno!.Nome,
+            NomeOrientador: banca.Tcc.Orientador?.Nome ?? "-",
+            Avaliadores: avaliadores,
+            DataHoraDefesaBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(banca.DataHora),
+            Local: banca.Local,
+            NotaFinal: banca.NotaFinal.Value,
+            MotivoReprovacao: motivoReprovacao,
+            DataGeracaoBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(DateTime.UtcNow)
+        );
+
+        var documento = new AtaPdfDocument(model);
+        var pdfBytes = documento.GeneratePdf();
+
+        return new AtaPdfResultado { Status = AtaPdfResultadoStatus.Sucesso, PdfBytes = pdfBytes };
+    }
+}

--- a/TccManager.Api/Services/Pdf/AtaPdfService.cs
+++ b/TccManager.Api/Services/Pdf/AtaPdfService.cs
@@ -3,15 +3,17 @@ using Microsoft.Extensions.Options;
 using QuestPDF.Fluent;
 using TccManager.Api.Data;
 using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
 
 namespace TccManager.Api.Services.Pdf;
 
 /// <summary>
-/// Orquestra a geração do PDF final da ata: carrega os dados via EF Core (única query,
-/// AsNoTracking — leitura pontual, ver docs/dados/2026-07-13-pdf-ata-questpdf.md), monta o
-/// <see cref="AtaPdfModel"/> resolvendo o polimorfismo de <c>BancaAvaliador</c> e a conversão
-/// de fuso, e delega o layout ao <see cref="AtaPdfDocument"/> (QuestPDF). Não conhece a
-/// fluent API do QuestPDF diretamente — apenas invoca <c>GeneratePdf()</c> sobre o documento.
+/// Orquestra a geração do PDF (final e rascunho) da ata: carrega os dados via EF Core
+/// (única query, AsNoTracking — leitura pontual, ver docs/dados/2026-07-13-pdf-ata-questpdf.md
+/// e docs/dados/2026-07-13-pdf-ata-rascunho-etapa2.md), monta o <see cref="AtaPdfModel"/>
+/// resolvendo o polimorfismo de <c>BancaAvaliador</c> e a conversão de fuso, e delega o
+/// layout ao <see cref="AtaPdfDocument"/> (QuestPDF). Não conhece a fluent API do QuestPDF
+/// diretamente — apenas invoca <c>GeneratePdf()</c> sobre o documento.
 /// </summary>
 public class AtaPdfService : IAtaPdfService
 {
@@ -26,25 +28,13 @@ public class AtaPdfService : IAtaPdfService
 
     public async Task<AtaPdfResultado> GerarAtaFinalAsync(int idBanca)
     {
-        var banca = await _context.Banca
-            .AsNoTracking()
-            .Include(b => b.Tcc).ThenInclude(t => t!.Aluno)
-            .Include(b => b.Tcc).ThenInclude(t => t!.Orientador)
-            .Include(b => b.Avaliadores).ThenInclude(a => a.Professor)
-            .Include(b => b.Avaliadores).ThenInclude(a => a.MembroExterno)
-            .FirstOrDefaultAsync(b => b.Id == idBanca);
+        var banca = await CarregarBancaComposicaoAsync(idBanca);
 
         if (banca == null)
             return new AtaPdfResultado { Status = AtaPdfResultadoStatus.BancaNaoEncontrada };
 
         if (banca.NotaFinal == null)
             return new AtaPdfResultado { Status = AtaPdfResultadoStatus.ResultadoNaoRegistrado };
-
-        var avaliadores = banca.Avaliadores
-            .Select(a => a.ProfessorId != null
-                ? new AtaMembroBancaModel(a.Professor!.Nome, null)
-                : new AtaMembroBancaModel(a.MembroExterno!.Nome, a.MembroExterno!.Instituicao))
-            .ToList();
 
         // Motivo de reprovação (Tcc.MotivoRejeicao) só aparece quando a banca de fato
         // reprovou o TCC — derivado do Status já persistido (fonte de verdade histórica),
@@ -53,23 +43,64 @@ public class AtaPdfService : IAtaPdfService
             ? banca.Tcc.MotivoRejeicao
             : null;
 
-        var model = new AtaPdfModel(
-            Instituicao: _options.Instituicao,
-            Curso: _options.Curso,
-            TccTitulo: banca.Tcc.Titulo,
-            NomeAluno: banca.Tcc.Aluno!.Nome,
-            NomeOrientador: banca.Tcc.Orientador?.Nome ?? "-",
-            Avaliadores: avaliadores,
-            DataHoraDefesaBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(banca.DataHora),
-            Local: banca.Local,
-            NotaFinal: banca.NotaFinal.Value,
-            MotivoReprovacao: motivoReprovacao,
-            DataGeracaoBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(DateTime.UtcNow)
-        );
+        var model = MontarModel(banca, notaFinal: banca.NotaFinal, motivoReprovacao: motivoReprovacao, rascunho: false);
 
         var documento = new AtaPdfDocument(model);
         var pdfBytes = documento.GeneratePdf();
 
         return new AtaPdfResultado { Status = AtaPdfResultadoStatus.Sucesso, PdfBytes = pdfBytes };
+    }
+
+    public async Task<AtaPdfResultado> GerarAtaRascunhoAsync(int idBanca)
+    {
+        var banca = await CarregarBancaComposicaoAsync(idBanca);
+
+        if (banca == null)
+            return new AtaPdfResultado { Status = AtaPdfResultadoStatus.BancaNaoEncontrada };
+
+        // Bloqueio definitivo (RNF-03): uma vez registrado o resultado, o rascunho não é
+        // mais servido — mesmo que o chamador ainda tenha um token/sessão válido por data.
+        if (banca.NotaFinal != null)
+            return new AtaPdfResultado { Status = AtaPdfResultadoStatus.ResultadoJaRegistrado };
+
+        var model = MontarModel(banca, notaFinal: null, motivoReprovacao: null, rascunho: true);
+
+        var documento = new AtaPdfDocument(model);
+        var pdfBytes = documento.GeneratePdf();
+
+        return new AtaPdfResultado { Status = AtaPdfResultadoStatus.Sucesso, PdfBytes = pdfBytes };
+    }
+
+    private Task<Banca?> CarregarBancaComposicaoAsync(int idBanca) =>
+        _context.Banca
+            .AsNoTracking()
+            .Include(b => b.Tcc).ThenInclude(t => t!.Aluno)
+            .Include(b => b.Tcc).ThenInclude(t => t!.Orientador)
+            .Include(b => b.Avaliadores).ThenInclude(a => a.Professor)
+            .Include(b => b.Avaliadores).ThenInclude(a => a.MembroExterno)
+            .FirstOrDefaultAsync(b => b.Id == idBanca);
+
+    private AtaPdfModel MontarModel(Banca banca, decimal? notaFinal, string? motivoReprovacao, bool rascunho)
+    {
+        var avaliadores = banca.Avaliadores
+            .Select(a => a.ProfessorId != null
+                ? new AtaMembroBancaModel(a.Professor!.Nome, null)
+                : new AtaMembroBancaModel(a.MembroExterno!.Nome, a.MembroExterno!.Instituicao))
+            .ToList();
+
+        return new AtaPdfModel(
+            Instituicao: _options.Instituicao,
+            Curso: _options.Curso,
+            TccTitulo: banca.Tcc!.Titulo,
+            NomeAluno: banca.Tcc.Aluno!.Nome,
+            NomeOrientador: banca.Tcc.Orientador?.Nome ?? "-",
+            Avaliadores: avaliadores,
+            DataHoraDefesaBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(banca.DataHora),
+            Local: banca.Local,
+            NotaFinal: notaFinal,
+            MotivoReprovacao: motivoReprovacao,
+            DataGeracaoBrasilia: BrasiliaTimeZoneService.ConverterDeUtcParaBrasilia(DateTime.UtcNow),
+            Rascunho: rascunho
+        );
     }
 }

--- a/TccManager.Api/Services/Pdf/IAtaPdfService.cs
+++ b/TccManager.Api/Services/Pdf/IAtaPdfService.cs
@@ -1,0 +1,30 @@
+namespace TccManager.Api.Services.Pdf;
+
+public enum AtaPdfResultadoStatus
+{
+    Sucesso,
+    BancaNaoEncontrada,
+    ResultadoNaoRegistrado
+}
+
+/// <summary>
+/// Resultado da geração do PDF final da ata. O <c>Status</c> permite ao controller
+/// diferenciar 404 (banca inexistente) de 409 (resultado ainda não registrado) sem
+/// precisar consultar o banco diretamente (ver RF-03/seção 5 da arquitetura).
+/// </summary>
+public class AtaPdfResultado
+{
+    public required AtaPdfResultadoStatus Status { get; init; }
+    public byte[]? PdfBytes { get; init; }
+}
+
+public interface IAtaPdfService
+{
+    /// <summary>
+    /// Gera o PDF final da ata (pós-resultado) para a banca informada, carregando os
+    /// dados já persistidos via EF Core. Não gera PDF parcial: se a banca não existir
+    /// ou o resultado ainda não tiver sido registrado (<c>NotaFinal == null</c>), o
+    /// <see cref="AtaPdfResultado.Status"/> indica o motivo e <c>PdfBytes</c> vem nulo.
+    /// </summary>
+    Task<AtaPdfResultado> GerarAtaFinalAsync(int idBanca);
+}

--- a/TccManager.Api/Services/Pdf/IAtaPdfService.cs
+++ b/TccManager.Api/Services/Pdf/IAtaPdfService.cs
@@ -4,13 +4,19 @@ public enum AtaPdfResultadoStatus
 {
     Sucesso,
     BancaNaoEncontrada,
-    ResultadoNaoRegistrado
+    ResultadoNaoRegistrado,
+
+    /// <summary>
+    /// Usado apenas pelo fluxo de rascunho (Etapa 2): <c>Banca.NotaFinal</c> já foi
+    /// preenchido, então o rascunho não é mais servido (RNF-03) — mapeado para 410 Gone.
+    /// </summary>
+    ResultadoJaRegistrado
 }
 
 /// <summary>
-/// Resultado da geração do PDF final da ata. O <c>Status</c> permite ao controller
-/// diferenciar 404 (banca inexistente) de 409 (resultado ainda não registrado) sem
-/// precisar consultar o banco diretamente (ver RF-03/seção 5 da arquitetura).
+/// Resultado da geração do PDF (final ou rascunho) da ata. O <c>Status</c> permite ao
+/// controller diferenciar 404 (banca inexistente) de 409/410 (resultado ainda não
+/// registrado / já registrado) sem precisar consultar o banco diretamente.
 /// </summary>
 public class AtaPdfResultado
 {
@@ -27,4 +33,13 @@ public interface IAtaPdfService
     /// <see cref="AtaPdfResultado.Status"/> indica o motivo e <c>PdfBytes</c> vem nulo.
     /// </summary>
     Task<AtaPdfResultado> GerarAtaFinalAsync(int idBanca);
+
+    /// <summary>
+    /// Gera o PDF rascunho pré-defesa (RF-01/Etapa 2): mesma composição, sem nota final,
+    /// sem motivo de reprovação e sem seção de assinaturas, disponível apenas enquanto
+    /// <c>Banca.NotaFinal == null</c>. Depois que o resultado é registrado, retorna
+    /// <see cref="AtaPdfResultadoStatus.ResultadoJaRegistrado"/> (410 Gone) mesmo que o
+    /// chamador ainda tenha um token/sessão tecnicamente válido (RNF-03).
+    /// </summary>
+    Task<AtaPdfResultado> GerarAtaRascunhoAsync(int idBanca);
 }

--- a/TccManager.Api/Services/Pdf/IRascunhoAtaTokenService.cs
+++ b/TccManager.Api/Services/Pdf/IRascunhoAtaTokenService.cs
@@ -1,0 +1,49 @@
+namespace TccManager.Api.Services.Pdf;
+
+public enum RascunhoTokenValidacaoStatus
+{
+    /// <summary>Token existe, não foi revogado, ainda não expirou por data e o resultado não foi registrado.</summary>
+    Valido,
+
+    /// <summary>
+    /// Token inexistente, revogado ou expirado por data. Deliberadamente unificado em um
+    /// único status (nunca detalhado ao chamador anônimo) para não vazar existência/estado
+    /// de tokens — ver docs/arquitetura/2026-07-13-pdf-ata-rascunho-etapa2.md, seção 5.
+    /// </summary>
+    Invalido,
+
+    /// <summary>Banca.NotaFinal já foi preenchido — bloqueio definitivo (RNF-03), independente da validade por data.</summary>
+    ResultadoRegistrado
+}
+
+/// <summary>Resultado da validação de um token de acesso ao rascunho, consumido pelo endpoint público.</summary>
+public class RascunhoTokenValidacao
+{
+    public required RascunhoTokenValidacaoStatus Status { get; init; }
+    public int BancaId { get; init; }
+}
+
+/// <summary>
+/// Emissão, validação e revogação do token opaco de acesso externo ao rascunho da ata
+/// (N2 Etapa 2). Segue o espírito de <c>AuthTokenService</c>: CSPRNG (32 bytes), hash
+/// SHA-256 armazenado (nunca o valor bruto), expiração e revogação. Nenhum controller
+/// manipula hash/CSPRNG diretamente — toda a lógica de token fica concentrada aqui.
+/// </summary>
+public interface IRascunhoAtaTokenService
+{
+    /// <summary>
+    /// Revoga qualquer token vigente do par (idempotência do reenvio) e cria um novo,
+    /// com <c>ExpiresAtUtc</c> = <c>Banca.DataHora</c>. Retorna o valor bruto do token
+    /// (existe apenas em memória, nunca persistido) para uso imediato na montagem do
+    /// link do e-mail.
+    /// </summary>
+    Task<string> GerarTokenAsync(int bancaId, int membroExternoId);
+
+    /// <summary>
+    /// Calcula o hash do token recebido e busca por hash (nunca compara pelo valor bruto).
+    /// </summary>
+    Task<RascunhoTokenValidacao> ValidarAsync(string tokenBruto);
+
+    /// <summary>Revoga o token vigente do par, se houver. Usado isoladamente pelo reenvio (RF-06).</summary>
+    Task RevogarTokenAtualAsync(int bancaId, int membroExternoId);
+}

--- a/TccManager.Api/Services/Pdf/RascunhoAtaTokenService.cs
+++ b/TccManager.Api/Services/Pdf/RascunhoAtaTokenService.cs
@@ -1,0 +1,116 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Api.Data;
+using TccManager.Shared.Models;
+
+namespace TccManager.Api.Services.Pdf;
+
+public class RascunhoAtaTokenService : IRascunhoAtaTokenService
+{
+    private readonly AppDbContext _context;
+
+    public RascunhoAtaTokenService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<string> GerarTokenAsync(int bancaId, int membroExternoId)
+    {
+        var banca = await _context.Banca
+            .AsNoTracking()
+            .FirstOrDefaultAsync(b => b.Id == bancaId);
+
+        if (banca == null)
+            throw new InvalidOperationException($"Banca {bancaId} não encontrada ao gerar token de rascunho.");
+
+        // Revoga qualquer token vigente do mesmo par antes de gerar o novo — garante a
+        // idempotência do reenvio (RF-06) e, junto com o índice único filtrado do banco,
+        // a invariante "no máximo 1 token ativo por par" (ver docs/dados, seção 3.1).
+        await RevogarAtivosSemSalvarAsync(bancaId, membroExternoId);
+
+        // CSPRNG (não Guid.NewGuid): o token é uma credencial de portador, precisa de
+        // garantia de imprevisibilidade criptográfica, não apenas unicidade — mesmo
+        // raciocínio já usado em AuthTokenService para o refresh token.
+        var tokenBruto = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+        var agora = DateTime.UtcNow;
+
+        var novoToken = new RascunhoAtaToken
+        {
+            BancaId = bancaId,
+            MembroExternoId = membroExternoId,
+            TokenHash = CalcularHash(tokenBruto),
+            CreatedAtUtc = agora,
+            ExpiresAtUtc = banca.DataHora
+        };
+
+        _context.RascunhoAtaTokens.Add(novoToken);
+        await _context.SaveChangesAsync();
+
+        return tokenBruto;
+    }
+
+    public async Task<RascunhoTokenValidacao> ValidarAsync(string tokenBruto)
+    {
+        var hash = CalcularHash(tokenBruto);
+
+        var token = await _context.RascunhoAtaTokens
+            .Include(t => t.Banca)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.TokenHash == hash);
+
+        // Token inexistente ou revogado: resposta genérica (Invalido) para não vazar
+        // existência/estado de token a um chamador anônimo.
+        if (token?.Banca == null || token.RevokedAtUtc != null)
+            return new RascunhoTokenValidacao { Status = RascunhoTokenValidacaoStatus.Invalido };
+
+        // Bloqueio definitivo (RNF-03): checado antes da expiração por data, para que o
+        // resultado já registrado sempre prevaleça (410) mesmo quando a data da banca já
+        // passou — os 3 pontos de acesso devem convergir no mesmo status nesse cenário.
+        if (token.Banca.NotaFinal != null)
+            return new RascunhoTokenValidacao { Status = RascunhoTokenValidacaoStatus.ResultadoRegistrado, BancaId = token.BancaId };
+
+        if (DateTime.UtcNow >= token.Banca.DataHora)
+            return new RascunhoTokenValidacao { Status = RascunhoTokenValidacaoStatus.Invalido };
+
+        return new RascunhoTokenValidacao { Status = RascunhoTokenValidacaoStatus.Valido, BancaId = token.BancaId };
+    }
+
+    public async Task RevogarTokenAtualAsync(int bancaId, int membroExternoId)
+    {
+        var alterouAlgum = await RevogarAtivosSemSalvarAsync(bancaId, membroExternoId);
+
+        if (alterouAlgum)
+            await _context.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Carrega os tokens ativos do par via change tracker (não <c>ExecuteUpdateAsync</c> —
+    /// o provider EF Core InMemory da suíte de testes não o suporta, mesmo motivo já
+    /// documentado em <c>AuthTokenService.RevokeAllForUserAsync</c>) e marca
+    /// <c>RevokedAtUtc</c>. Não salva: quem chama decide o momento do <c>SaveChangesAsync</c>.
+    /// </summary>
+    private async Task<bool> RevogarAtivosSemSalvarAsync(int bancaId, int membroExternoId)
+    {
+        var tokensAtivos = await _context.RascunhoAtaTokens
+            .Where(t => t.BancaId == bancaId && t.MembroExternoId == membroExternoId && t.RevokedAtUtc == null)
+            .ToListAsync();
+
+        if (tokensAtivos.Count == 0)
+            return false;
+
+        var agora = DateTime.UtcNow;
+        foreach (var token in tokensAtivos)
+        {
+            token.RevokedAtUtc = agora;
+        }
+
+        return true;
+    }
+
+    private static string CalcularHash(string valor)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(valor));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+}

--- a/TccManager.Api/TccManager.Api.csproj
+++ b/TccManager.Api/TccManager.Api.csproj
@@ -25,6 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="QuestPDF" Version="2026.7.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />

--- a/TccManager.Api/appsettings.json
+++ b/TccManager.Api/appsettings.json
@@ -32,6 +32,11 @@
       "PermitLimit": 5,
       "WindowSeconds": 60,
       "QueueLimit": 0
+    },
+    "RascunhoPublico": {
+      "PermitLimit": 20,
+      "WindowSeconds": 60,
+      "QueueLimit": 0
     }
   },
   "AllowedHosts": "*",
@@ -58,5 +63,9 @@
   "Ata": {
     "Instituicao": "",
     "Curso": ""
+  },
+  "App": {
+    "PublicApiBaseUrl": "",
+    "ClientBaseUrl": ""
   }
 }

--- a/TccManager.Api/appsettings.json
+++ b/TccManager.Api/appsettings.json
@@ -54,5 +54,9 @@
       "UseSsl": false
     },
     "From": ""
+  },
+  "Ata": {
+    "Instituicao": "",
+    "Curso": ""
   }
 }

--- a/TccManager.Client/Layout/NavMenu.razor
+++ b/TccManager.Client/Layout/NavMenu.razor
@@ -71,6 +71,9 @@
                     <NavLink class="nav-link text-white" href="/coordenador/registrar-resultado">
                         <i class="bi bi-award-fill me-2"></i> Registrar Resultado
                     </NavLink>
+                    <NavLink class="nav-link text-white" href="/coordenador/bancas-concluidas">
+                        <i class="bi bi-journal-check me-2"></i> Bancas Concluídas
+                    </NavLink>
                 </li>
             </Authorized>
         </AuthorizeView>

--- a/TccManager.Client/Pages/Avaliador/ConvitesBanca.razor
+++ b/TccManager.Client/Pages/Avaliador/ConvitesBanca.razor
@@ -48,6 +48,18 @@
                         </div>
 
                         <div class="card-footer bg-light text-end">
+                            <button class="btn btn-outline-primary shadow-sm me-2" disabled="@(bancaIdBaixandoRascunho == convite.BancaId)" @onclick="() => BaixarAtaRascunho(convite.BancaId)">
+                                @if (bancaIdBaixandoRascunho == convite.BancaId)
+                                {
+                                    <span class="spinner-border spinner-border-sm me-1"></span>
+                                }
+                                else
+                                {
+                                    <i class="bi bi-file-earmark-pdf me-1"></i>
+                                }
+                                Baixar Rascunho da Ata
+                            </button>
+
                             @if (!string.IsNullOrEmpty(convite.ArquivoFinalCaminho))
                             {
                                 <a href="@($"{Http.BaseAddress?.ToString().TrimEnd('/')}{convite.ArquivoFinalCaminho}")" target="_blank" class="btn btn-success shadow-sm">
@@ -71,6 +83,7 @@
 @code {
     private bool carregando = true;
     private List<ConviteBancaDto> convites = new();
+    private int? bancaIdBaixandoRascunho;
 
     protected override async Task OnInitializedAsync()
     {
@@ -91,6 +104,33 @@
         finally
         {
             carregando = false;
+        }
+    }
+
+    // RF-03/Etapa 2: download do PDF rascunho pré-defesa. O backend valida (RNF-01) que o
+    // professor autenticado é de fato um avaliador desta banca; 403/404/410 exibem o erro.
+    private async Task BaixarAtaRascunho(int bancaId)
+    {
+        bancaIdBaixandoRascunho = bancaId;
+        try
+        {
+            var response = await Http.GetAsync($"api/avaliador/banca/{bancaId}/ata-rascunho-pdf");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var base64 = Convert.ToBase64String(bytes);
+                await JSRuntime.InvokeVoidAsync("downloadFileFromBytes", $"ata-rascunho-{bancaId}.pdf", "application/pdf", base64);
+            }
+            else
+            {
+                var erro = await response.Content.ReadAsStringAsync();
+                await JSRuntime.InvokeVoidAsync("alert", $"Erro ao baixar o rascunho da ata: {erro}");
+            }
+        }
+        finally
+        {
+            bancaIdBaixandoRascunho = null;
         }
     }
 }

--- a/TccManager.Client/Pages/Coordenador/BancasConcluidas.razor
+++ b/TccManager.Client/Pages/Coordenador/BancasConcluidas.razor
@@ -1,0 +1,120 @@
+@page "/coordenador/bancas-concluidas"
+@using Microsoft.AspNetCore.Authorization
+@using TccManager.Shared.DTOs
+@attribute [Authorize(Roles = "Coordenador")]
+@inject HttpClient Http
+@inject IJSRuntime JSRuntime
+
+<div class="container mt-4">
+    <h2 class="mb-4"><i class="bi bi-journal-check me-2"></i> Bancas Concluídas</h2>
+
+    @if (carregando)
+    {
+        <div class="text-center py-5"><div class="spinner-border text-success"></div></div>
+    }
+    else if (resultado == null || !resultado.Items.Any())
+    {
+        <div class="alert alert-light text-center shadow-sm">
+            <i class="bi bi-info-circle me-2"></i> Nenhuma banca concluída até o momento.
+        </div>
+    }
+    else
+    {
+        <div class="card shadow-sm border-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Aluno</th>
+                            <th>Título do TCC</th>
+                            <th>Data da Banca</th>
+                            <th>Nota</th>
+                            <th>Status</th>
+                            <th class="text-end">Ação</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var banca in resultado.Items)
+                        {
+                            <tr>
+                                <td class="fw-bold">@banca.NomeAluno</td>
+                                <td>@banca.TccTitulo</td>
+                                <td>@banca.DataHora.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
+                                <td>@banca.NotaFinal.ToString("0.0")</td>
+                                <td>
+                                    @if (banca.Aprovado)
+                                    {
+                                        <span class="badge bg-success">Aprovado</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-danger">Reprovado</span>
+                                    }
+                                </td>
+                                <td class="text-end">
+                                    <button class="btn btn-sm btn-outline-primary" disabled="@(bancaIdBaixando == banca.BancaId)" @onclick="() => BaixarAtaPdf(banca.BancaId)">
+                                        @if (bancaIdBaixando == banca.BancaId)
+                                        {
+                                            <span class="spinner-border spinner-border-sm me-1"></span>
+                                        }
+                                        else
+                                        {
+                                            <i class="bi bi-file-earmark-pdf me-1"></i>
+                                        }
+                                        Baixar PDF
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <Paginacao PaginaAtual="resultado.CurrentPage" TotalPaginas="resultado.TotalPages" OnMudarPagina="CarregarPagina" />
+    }
+</div>
+
+@code {
+    private bool carregando = true;
+    private PagedResult<BancaConcluidaDto>? resultado;
+    private int? bancaIdBaixando;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarPagina(1);
+    }
+
+    private async Task CarregarPagina(int pagina)
+    {
+        carregando = true;
+        try
+        {
+            resultado = await Http.GetFromJsonAsync<PagedResult<BancaConcluidaDto>>(
+                $"api/coordenador/bancas-concluidas?page={pagina}&pageSize={PaginacaoQuery.DefaultPageSize}");
+        }
+        finally { carregando = false; }
+    }
+
+    private async Task BaixarAtaPdf(int bancaId)
+    {
+        bancaIdBaixando = bancaId;
+        try
+        {
+            var response = await Http.GetAsync($"api/coordenador/banca/{bancaId}/ata-pdf");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var base64 = Convert.ToBase64String(bytes);
+                await JSRuntime.InvokeVoidAsync("downloadFileFromBytes", $"ata-defesa-{bancaId}.pdf", "application/pdf", base64);
+            }
+            else
+            {
+                var erro = await response.Content.ReadAsStringAsync();
+                await JSRuntime.InvokeVoidAsync("alert", $"Erro ao baixar a ata: {erro}");
+            }
+        }
+        finally { bancaIdBaixando = null; }
+    }
+}

--- a/TccManager.Client/Pages/Coordenador/RegistroResultadoBanca.razor
+++ b/TccManager.Client/Pages/Coordenador/RegistroResultadoBanca.razor
@@ -62,64 +62,86 @@
     <div class="modal fade show" style="display:block; background-color: rgba(0,0,0,0.5);" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content border-primary">
-                <div class="modal-header bg-primary text-white">
-                    <h5 class="modal-title">Registrar Resultado: @nomeAlunoSelecionado</h5>
-                    <button type="button" class="btn-close btn-close-white" @onclick="FecharModal"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label fw-bold">Nota Final</label>
-                        <input type="number" step="0.1" min="0" max="100" class="form-control form-control-lg text-center"
-                               @bind="notaFinal" @bind:after="AtualizarStatusAprovacao" placeholder="Ex: 85,0" />
-
-                        @if (notaFinal > 0)
-                        {
-                            @if (notaAprova)
-                            {
-                                <div class="alert alert-success mt-2 py-2 mb-0 text-center">
-                                    <i class="bi bi-check-circle-fill me-2"></i> Nota aprova o TCC (mínimo: @notaMinimaExibicao)
-                                </div>
-                            }
-                            else
-                            {
-                                <div class="alert alert-danger mt-2 py-2 mb-0 text-center">
-                                    <i class="bi bi-x-circle-fill me-2"></i> Nota reprova o TCC (mínimo: @notaMinimaExibicao)
-                                </div>
-                            }
-                        }
+                @if (resultadoRegistrado)
+                {
+                    <div class="modal-header bg-success text-white">
+                        <h5 class="modal-title"><i class="bi bi-check-circle-fill me-2"></i>Resultado Registrado</h5>
                     </div>
+                    <div class="modal-body text-center py-4">
+                        <p>@mensagemSucesso</p>
+                        <button type="button" class="btn btn-outline-primary" disabled="@baixandoAta" @onclick="() => BaixarAtaPdf(bancaIdSelecionada)">
+                            @if (baixandoAta)
+                            {
+                                <span class="spinner-border spinner-border-sm me-2"></span>
+                            }
+                            <i class="bi bi-file-earmark-pdf me-1"></i> Baixar Ata (PDF)
+                        </button>
+                    </div>
+                    <div class="modal-footer bg-light">
+                        <button type="button" class="btn btn-secondary" @onclick="FecharModal">Fechar</button>
+                    </div>
+                }
+                else
+                {
+                    <div class="modal-header bg-primary text-white">
+                        <h5 class="modal-title">Registrar Resultado: @nomeAlunoSelecionado</h5>
+                        <button type="button" class="btn-close btn-close-white" @onclick="FecharModal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label fw-bold">Nota Final</label>
+                            <input type="number" step="0.1" min="0" max="100" class="form-control form-control-lg text-center"
+                                   @bind="notaFinal" @bind:after="AtualizarStatusAprovacao" placeholder="Ex: 85,0" />
 
-                    @if (notaFinal > 0 && !notaAprova)
-                    {
-                        <div class="mb-4">
-                            <label class="form-label fw-bold text-danger">Motivo da Reprovação</label>
-                            <textarea class="form-control" rows="3" @bind="motivoReprovacao"
-                                      placeholder="Descreva o motivo da reprovação na banca..."></textarea>
-                            <small class="text-muted">Obrigatório quando a nota é inferior ao mínimo de aprovação.</small>
+                            @if (notaFinal > 0)
+                            {
+                                @if (notaAprova)
+                                {
+                                    <div class="alert alert-success mt-2 py-2 mb-0 text-center">
+                                        <i class="bi bi-check-circle-fill me-2"></i> Nota aprova o TCC (mínimo: @notaMinimaExibicao)
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="alert alert-danger mt-2 py-2 mb-0 text-center">
+                                        <i class="bi bi-x-circle-fill me-2"></i> Nota reprova o TCC (mínimo: @notaMinimaExibicao)
+                                    </div>
+                                }
+                            }
                         </div>
-                    }
 
-                    <div class="mb-4">
-                        <label class="form-label fw-bold">Arquivo da Ata Assinada (PDF)</label>
-                        <InputFile OnChange="CarregarArquivo" class="form-control" accept=".pdf" />
-                        @if (arquivoAta != null)
+                        @if (notaFinal > 0 && !notaAprova)
                         {
-                            <small class="text-success mt-1 d-block"><i class="bi bi-check-circle me-1"></i> Arquivo selecionado: @arquivoAta.Name</small>
+                            <div class="mb-4">
+                                <label class="form-label fw-bold text-danger">Motivo da Reprovação</label>
+                                <textarea class="form-control" rows="3" @bind="motivoReprovacao"
+                                          placeholder="Descreva o motivo da reprovação na banca..."></textarea>
+                                <small class="text-muted">Obrigatório quando a nota é inferior ao mínimo de aprovação.</small>
+                            </div>
                         }
+
+                        <div class="mb-4">
+                            <label class="form-label fw-bold">Arquivo da Ata Assinada (PDF)</label>
+                            <InputFile OnChange="CarregarArquivo" class="form-control" accept=".pdf" />
+                            @if (arquivoAta != null)
+                            {
+                                <small class="text-success mt-1 d-block"><i class="bi bi-check-circle me-1"></i> Arquivo selecionado: @arquivoAta.Name</small>
+                            }
+                        </div>
                     </div>
-                </div>
-                <div class="modal-footer bg-light">
-                    <button type="button" class="btn btn-secondary" @onclick="FecharModal">Cancelar</button>
-                    <button type="button" class="btn @(notaAprova ? "btn-success" : "btn-danger")"
-                            disabled="@(arquivoAta == null || enviando || notaFinal <= 0 || (!notaAprova && string.IsNullOrWhiteSpace(motivoReprovacao)))"
-                            @onclick="SalvarResultado">
-                        @if (enviando)
-                        {
-                            <span class="spinner-border spinner-border-sm me-2"></span>
-                        }
-                        <i class="bi bi-save me-1"></i> @(notaAprova ? "Confirmar Aprovação" : "Confirmar Reprovação")
-                    </button>
-                </div>
+                    <div class="modal-footer bg-light">
+                        <button type="button" class="btn btn-secondary" @onclick="FecharModal">Cancelar</button>
+                        <button type="button" class="btn @(notaAprova ? "btn-success" : "btn-danger")"
+                                disabled="@(arquivoAta == null || enviando || notaFinal <= 0 || (!notaAprova && string.IsNullOrWhiteSpace(motivoReprovacao)))"
+                                @onclick="SalvarResultado">
+                            @if (enviando)
+                            {
+                                <span class="spinner-border spinner-border-sm me-2"></span>
+                            }
+                            <i class="bi bi-save me-1"></i> @(notaAprova ? "Confirmar Aprovação" : "Confirmar Reprovação")
+                        </button>
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -138,6 +160,12 @@
     private const string notaMinimaExibicao = "60,0";
     private bool notaAprova = true;
     private string motivoReprovacao = string.Empty;
+
+    // Estado de sucesso pós-registro (RF-05): mantém o modal aberto mostrando o botão
+    // de download do PDF da ata, em vez de fechar direto após o alert.
+    private bool resultadoRegistrado = false;
+    private string mensagemSucesso = string.Empty;
+    private bool baixandoAta = false;
 
     // Dados do Formulário
     private decimal notaFinal = 0;
@@ -166,13 +194,46 @@
         arquivoAta = null;
         motivoReprovacao = string.Empty;
         notaAprova = true;
+        resultadoRegistrado = false;
+        mensagemSucesso = string.Empty;
         exibirModal = true;
     }
 
-    private void FecharModal()
+    private async Task FecharModal()
     {
+        var precisaRecarregar = resultadoRegistrado;
+
         exibirModal = false;
         arquivoAta = null;
+        resultadoRegistrado = false;
+        mensagemSucesso = string.Empty;
+
+        if (precisaRecarregar)
+        {
+            await CarregarListas();
+        }
+    }
+
+    private async Task BaixarAtaPdf(int bancaId)
+    {
+        baixandoAta = true;
+        try
+        {
+            var response = await Http.GetAsync($"api/coordenador/banca/{bancaId}/ata-pdf");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var base64 = Convert.ToBase64String(bytes);
+                await JSRuntime.InvokeVoidAsync("downloadFileFromBytes", $"ata-defesa-{bancaId}.pdf", "application/pdf", base64);
+            }
+            else
+            {
+                var erro = await response.Content.ReadAsStringAsync();
+                await JSRuntime.InvokeVoidAsync("alert", $"Erro ao baixar a ata: {erro}");
+            }
+        }
+        finally { baixandoAta = false; }
     }
 
     private void CarregarArquivo(InputFileChangeEventArgs e)
@@ -217,12 +278,10 @@
 
             if (response.IsSuccessStatusCode)
             {
-                var mensagem = notaAprova
+                mensagemSucesso = notaAprova
                     ? "Nota e Ata registradas com sucesso! O TCC foi finalizado."
                     : "Resultado registrado. O TCC foi marcado como reprovado.";
-                await JSRuntime.InvokeVoidAsync("alert", mensagem);
-                FecharModal();
-                await CarregarListas();
+                resultadoRegistrado = true;
             }
             else
             {

--- a/TccManager.Client/Pages/Coordenador/RegistroResultadoBanca.razor
+++ b/TccManager.Client/Pages/Coordenador/RegistroResultadoBanca.razor
@@ -42,6 +42,37 @@
                                         <td>@banca.TccTitulo</td>
                                         <td>@banca.DataHora.ToLocalTime().ToString("dd/MM/yyyy HH:mm")</td>
                                         <td class="text-end">
+                                            <button class="btn btn-sm btn-outline-secondary me-1" disabled="@(bancaIdBaixandoRascunho == banca.TccId)" @onclick="() => BaixarAtaRascunho(banca.TccId)">
+                                                @if (bancaIdBaixandoRascunho == banca.TccId)
+                                                {
+                                                    <span class="spinner-border spinner-border-sm me-1"></span>
+                                                }
+                                                else
+                                                {
+                                                    <i class="bi bi-file-earmark-pdf me-1"></i>
+                                                }
+                                                Rascunho
+                                            </button>
+
+                                            @if (banca.MembrosExternos.Any())
+                                            {
+                                                <div class="dropdown d-inline-block me-1">
+                                                    <button class="btn btn-sm btn-outline-warning dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                                                        <i class="bi bi-envelope-arrow-up me-1"></i> Reenviar Rascunho
+                                                    </button>
+                                                    <ul class="dropdown-menu dropdown-menu-end">
+                                                        @foreach (var membro in banca.MembrosExternos)
+                                                        {
+                                                            <li>
+                                                                <button class="dropdown-item" disabled="@(membroExternoIdReenviando == membro.MembroExternoId)" @onclick="() => ReenviarRascunho(banca.TccId, membro.MembroExternoId, membro.Nome)">
+                                                                    @membro.Nome
+                                                                </button>
+                                                            </li>
+                                                        }
+                                                    </ul>
+                                                </div>
+                                            }
+
                                             <button class="btn btn-sm btn-primary" @onclick="() => AbrirModal(banca.TccId, banca.NomeAluno)">
                                                 <i class="bi bi-file-earmark-arrow-up"></i> Registrar Resultado
                                             </button>
@@ -171,6 +202,11 @@
     private decimal notaFinal = 0;
     private IBrowserFile? arquivoAta;
 
+    // Rascunho pré-defesa (N2 Etapa 2): download pelo Coordenador e reenvio de token por
+    // membro externo (RF-06).
+    private int? bancaIdBaixandoRascunho;
+    private int? membroExternoIdReenviando;
+
     protected override async Task OnInitializedAsync()
     {
         await CarregarListas();
@@ -234,6 +270,48 @@
             }
         }
         finally { baixandoAta = false; }
+    }
+
+    private async Task BaixarAtaRascunho(int bancaId)
+    {
+        bancaIdBaixandoRascunho = bancaId;
+        try
+        {
+            var response = await Http.GetAsync($"api/coordenador/banca/{bancaId}/ata-rascunho-pdf");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var base64 = Convert.ToBase64String(bytes);
+                await JSRuntime.InvokeVoidAsync("downloadFileFromBytes", $"ata-rascunho-{bancaId}.pdf", "application/pdf", base64);
+            }
+            else
+            {
+                var erro = await response.Content.ReadAsStringAsync();
+                await JSRuntime.InvokeVoidAsync("alert", $"Erro ao baixar o rascunho da ata: {erro}");
+            }
+        }
+        finally { bancaIdBaixandoRascunho = null; }
+    }
+
+    private async Task ReenviarRascunho(int bancaId, int membroExternoId, string nomeMembro)
+    {
+        membroExternoIdReenviando = membroExternoId;
+        try
+        {
+            var response = await Http.PostAsync($"api/coordenador/banca/{bancaId}/membro-externo/{membroExternoId}/reenviar-rascunho", null);
+
+            if (response.IsSuccessStatusCode)
+            {
+                await JSRuntime.InvokeVoidAsync("alert", $"Novo link de acesso ao rascunho enviado para {nomeMembro}.");
+            }
+            else
+            {
+                var erro = await response.Content.ReadAsStringAsync();
+                await JSRuntime.InvokeVoidAsync("alert", $"Erro ao reenviar o rascunho: {erro}");
+            }
+        }
+        finally { membroExternoIdReenviando = null; }
     }
 
     private void CarregarArquivo(InputFileChangeEventArgs e)

--- a/TccManager.Client/wwwroot/index.html
+++ b/TccManager.Client/wwwroot/index.html
@@ -31,6 +31,7 @@
     <script src="_framework/blazor.webassembly.js"></script>
 
     <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/downloadFile.js"></script>
 </body>
 
 </html>

--- a/TccManager.Client/wwwroot/js/downloadFile.js
+++ b/TccManager.Client/wwwroot/js/downloadFile.js
@@ -1,0 +1,24 @@
+// Helper único de download de arquivo binário (blob) para o Blazor WASM, usado pelas
+// telas do Coordenador que baixam o PDF da ata (RF-05). Recebe os bytes já em base64
+// (o C# converte via Convert.ToBase64String) e materializa o download via um link
+// temporário com uma Object URL — evita manter o arquivo inteiro como data URI na tag <a>.
+window.downloadFileFromBytes = (fileName, contentType, bytesBase64) => {
+    const bytes = atob(bytesBase64);
+    const buffer = new Uint8Array(bytes.length);
+
+    for (let i = 0; i < bytes.length; i++) {
+        buffer[i] = bytes.charCodeAt(i);
+    }
+
+    const blob = new Blob([buffer], { type: contentType });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+};

--- a/TccManager.Shared/DTOs/CoordenadorDtos.cs
+++ b/TccManager.Shared/DTOs/CoordenadorDtos.cs
@@ -43,6 +43,20 @@ public class BancaPendenteDto
     public string Local { get; set; } = string.Empty;
     public string TccTitulo { get; set; } = string.Empty;
     public string NomeAluno { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Membros externos avaliadores desta banca (N2 Etapa 2) — usado pelo Client para
+    /// renderizar o botão de reenvio de token do rascunho (RF-06) individualmente por
+    /// membro. Vazio se a banca só tiver avaliadores internos.
+    /// </summary>
+    public List<MembroExternoBancaDto> MembrosExternos { get; set; } = new();
+}
+
+/// <summary>Membro externo avaliador de uma banca, usado por BancaPendenteDto (RF-06/Etapa 2).</summary>
+public class MembroExternoBancaDto
+{
+    public int MembroExternoId { get; set; }
+    public string Nome { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/TccManager.Shared/DTOs/CoordenadorDtos.cs
+++ b/TccManager.Shared/DTOs/CoordenadorDtos.cs
@@ -44,3 +44,18 @@ public class BancaPendenteDto
     public string TccTitulo { get; set; } = string.Empty;
     public string NomeAluno { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// Item da listagem de bancas já concluídas (resultado registrado). Usa "BancaId"
+/// (e não "TccId", como o já existente BancaPendenteDto faz de forma enganosa) para
+/// que o Client monte a rota banca/{BancaId}/ata-pdf sem ambiguidade.
+/// </summary>
+public class BancaConcluidaDto
+{
+    public int BancaId { get; set; }
+    public string TccTitulo { get; set; } = string.Empty;
+    public string NomeAluno { get; set; } = string.Empty;
+    public DateTime DataHora { get; set; }
+    public decimal NotaFinal { get; set; }
+    public bool Aprovado { get; set; }
+}

--- a/TccManager.Shared/Models/RascunhoAtaToken.cs
+++ b/TccManager.Shared/Models/RascunhoAtaToken.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TccManager.Shared.Models;
+
+/// <summary>
+/// Token opaco de acesso ao PDF rascunho da ata (N2 Etapa 2), emitido por par
+/// (Banca, MembroExterno). Segue o espírito de <see cref="RefreshToken"/>: CSPRNG,
+/// apenas o hash SHA-256 é persistido (<see cref="TokenHash"/>), com expiração e
+/// suporte a revogação (ver docs/dados/2026-07-13-pdf-ata-rascunho-etapa2.md).
+/// </summary>
+[Table("rascunho_ata_tokens")]
+public class RascunhoAtaToken
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int BancaId { get; set; }
+    [ForeignKey("BancaId")]
+    public Banca? Banca { get; set; }
+
+    public int MembroExternoId { get; set; }
+    [ForeignKey("MembroExternoId")]
+    public MembroExterno? MembroExterno { get; set; }
+
+    [Required]
+    [MaxLength(64)]
+    public string TokenHash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Snapshot de <c>Banca.DataHora</c> no momento da emissão — não autoritativo (a
+    /// checagem de expiração é feita ao vivo contra <c>Banca.DataHora</c>); mantido por
+    /// paridade estrutural com <see cref="RefreshToken"/> e para auditoria.
+    /// </summary>
+    public DateTime ExpiresAtUtc { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>Null = token vigente. Setado no reenvio (RF-06) ou invalidação.</summary>
+    public DateTime? RevokedAtUtc { get; set; }
+}

--- a/TccManager.Tests/Configuration/RateLimitingRascunhoPublicoTests.cs
+++ b/TccManager.Tests/Configuration/RateLimitingRascunhoPublicoTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using Xunit;
+
+namespace TccManager.Tests.Configuration;
+
+/// <summary>
+/// Testes de integração da política de rate limiting "rascunho-publico" aplicada ao endpoint
+/// público GET /api/rascunho-ata/{token} (Etapa 2, RNF de defesa contra enumeração de token).
+///
+/// Diferença em relação ao endpoint de login: aqui um token inválido retorna 404 (não 401),
+/// então a asserção "dentro do limite" verifica != TooManyRequests. PermitLimit padrão é 20
+/// (RateLimiting:RascunhoPublico:PermitLimit no appsettings.json), mais folgado que o login.
+/// Cada instância de factory tem seu próprio limitador (serviço por host), isolando os casos.
+/// </summary>
+public class RateLimitingRascunhoPublicoTests
+{
+    private const int PermitLimit = 20;
+
+    private static string RotaComTokenInvalido() => $"/api/rascunho-ata/{new string('0', 64)}";
+
+    [Fact]
+    public async Task RequisicaoAcimaDoLimite_Retorna429ComRetryAfter()
+    {
+        using var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var rota = RotaComTokenInvalido();
+
+        // As PermitLimit primeiras requisições passam pelo limitador (retornam 404, não 429).
+        for (var i = 1; i <= PermitLimit; i++)
+        {
+            var permitida = await client.GetAsync(rota);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, permitida.StatusCode);
+        }
+
+        // A requisição seguinte dentro da mesma janela é bloqueada.
+        var bloqueada = await client.GetAsync(rota);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, bloqueada.StatusCode);
+        Assert.True(bloqueada.Headers.Contains("Retry-After"),
+            "A resposta 429 deve conter o header Retry-After.");
+        var retryAfter = bloqueada.Headers.GetValues("Retry-After").First();
+        Assert.True(int.TryParse(retryAfter, out var segundos),
+            $"Retry-After deveria ser um inteiro em segundos, mas foi '{retryAfter}'.");
+        Assert.InRange(segundos, 1, 60);
+    }
+
+    [Fact]
+    public async Task DentroDoLimite_NenhumaEhBloqueada()
+    {
+        using var factory = new TccApiFactory();
+        var client = factory.CreateClient();
+        var rota = RotaComTokenInvalido();
+
+        for (var i = 1; i <= PermitLimit; i++)
+        {
+            var resp = await client.GetAsync(rota);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+    }
+}

--- a/TccManager.Tests/Controllers/AvaliadorController_AtaRascunhoPdf_Tests.cs
+++ b/TccManager.Tests/Controllers/AvaliadorController_AtaRascunhoPdf_Tests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração do endpoint GET /api/avaliador/banca/{idBanca}/ata-rascunho-pdf (RNF-01/Etapa 2).
+/// A validação de vínculo é explícita: só o professor que é BancaAvaliador daquela banca
+/// específica baixa o rascunho. Qualquer outro professor (inclusive o orientador, que não
+/// tem vínculo BancaAvaliador — decisão 6) recebe 403 Forbidden, não bastando ter o papel
+/// "Professor". Banca inexistente também cai em 403, pois sem vínculo o controller retorna
+/// Forbid() antes de chegar à resolução de banca (não expõe existência).
+/// </summary>
+public class AvaliadorController_AtaRascunhoPdf_Tests
+{
+    private sealed record Semeadura(int BancaId, int AvaliadorId, int OrientadorId, int OutroProfId);
+
+    private static async Task<Semeadura> SemearBancaAsync(
+        WebRootIsolatedApiFactory factory,
+        decimal? notaFinal = null,
+        StatusTcc statusTcc = StatusTcc.AguardandoDefesa)
+    {
+        using var context = factory.CriarContextoDireto();
+
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var avaliador = new Usuario { Nome = "Avaliador Vinculado", Email = "aval@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var outroProf = new Usuario { Nome = "Prof de Outra Banca", Email = "outro@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador, avaliador, outroProf);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC Avaliador",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = statusTcc,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = DateTime.UtcNow.AddDays(2), Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, ProfessorId = avaliador.Id });
+        await context.SaveChangesAsync();
+
+        return new Semeadura(banca.Id, avaliador.Id, orientador.Id, outroProf.Id);
+    }
+
+    [Fact]
+    public async Task AvaliadorVinculado_RetornaPdf()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory);
+        var client = factory.CreateClientAutenticado(s.AvaliadorId, "Professor");
+
+        var response = await client.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length >= 4 && bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46,
+            "O corpo da resposta não começa com a assinatura %PDF.");
+    }
+
+    [Fact]
+    public async Task ProfessorNaoVinculado_Retorna403()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory);
+        var client = factory.CreateClientAutenticado(s.OutroProfId, "Professor");
+
+        var response = await client.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Orientador_MesmaBanca_Retorna403()
+    {
+        // O orientador tem papel Professor mas NÃO é BancaAvaliador — não deve acessar (decisão 6).
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory);
+        var client = factory.CreateClientAutenticado(s.OrientadorId, "Professor");
+
+        var response = await client.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BancaInexistente_Retorna403()
+    {
+        // Sem vínculo BancaAvaliador para a banca pedida (inexistente) → Forbid antes de 404.
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory);
+        var client = factory.CreateClientAutenticado(s.AvaliadorId, "Professor");
+
+        var response = await client.GetAsync("/api/avaliador/banca/9999/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task NaoAutenticado_Retorna401()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory);
+        var client = factory.CreateClient(); // sem cabeçalhos de auth
+
+        var response = await client.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AvaliadorVinculado_ResultadoRegistrado_Retorna410()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory, notaFinal: 90m, statusTcc: StatusTcc.Finalizado);
+        var client = factory.CreateClientAutenticado(s.AvaliadorId, "Professor");
+
+        var response = await client.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+    }
+}

--- a/TccManager.Tests/Controllers/CoordenadorController_AtaPdf_Tests.cs
+++ b/TccManager.Tests/Controllers/CoordenadorController_AtaPdf_Tests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração do endpoint GET /api/coordenador/banca/{idBanca}/ata-pdf através do pipeline
+/// HTTP real (WebApplicationFactory + EF InMemory). Cobre os três desfechos documentados em
+/// docs/implementacao/2026-07-13-pdf-ata-questpdf.md: 404 (banca inexistente), 409 (resultado
+/// não registrado) e 200 (application/pdf com corpo iniciando em %PDF), incluindo aprovação,
+/// reprovação com motivo e uma banca com avaliador externo na composição.
+/// </summary>
+public class CoordenadorController_AtaPdf_Tests
+{
+    private const int idCoordenador = 1;
+
+    private static async Task<(WebRootIsolatedApiFactory factory, int bancaId)> SemearBancaAsync(
+        decimal? notaFinal,
+        StatusTcc statusTcc,
+        string? motivoRejeicao = null,
+        bool comAvaliadorExterno = false)
+    {
+        var factory = new WebRootIsolatedApiFactory();
+        using var context = factory.CriarContextoDireto();
+
+        var aluno = new Usuario { Nome = "Aluno Ata", Email = "aluno.ata@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Prof. Orientador", Email = "orient.ata@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var avaliadorInterno = new Usuario { Nome = "Prof. Avaliador", Email = "aval.ata@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador, avaliadorInterno);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC para Ata em PDF",
+            Resumo = "Resumo",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = statusTcc,
+            MotivoRejeicao = motivoRejeicao,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca
+        {
+            TccId = tcc.Id,
+            DataHora = DateTime.UtcNow.AddDays(-1),
+            Local = "Auditório Central",
+            NotaFinal = notaFinal
+        };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, ProfessorId = avaliadorInterno.Id });
+
+        if (comAvaliadorExterno)
+        {
+            var externo = new MembroExterno { Nome = "Dra. Convidada Externa", Email = "convidada@outra.edu", Instituicao = "Universidade Parceira" };
+            context.MembrosExternos.Add(externo);
+            await context.SaveChangesAsync();
+            context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        }
+
+        await context.SaveChangesAsync();
+        return (factory, banca.Id);
+    }
+
+    private static async Task AssertPdfValidoAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length > 100, "PDF retornado é suspeito de estar vazio/truncado.");
+        Assert.True(
+            bytes.Length >= 4 && bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46,
+            "O corpo da resposta não começa com a assinatura %PDF.");
+    }
+
+    [Fact]
+    public async Task BancaInexistente_RetornaNotFound()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/banca/9999/ata-pdf");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BancaSemResultadoRegistrado_RetornaConflict()
+    {
+        var (factory, bancaId) = await SemearBancaAsync(notaFinal: null, statusTcc: StatusTcc.AguardandoDefesa);
+        using var _ = factory;
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{bancaId}/ata-pdf");
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BancaAprovada_RetornaPdf()
+    {
+        var (factory, bancaId) = await SemearBancaAsync(notaFinal: 90.0m, statusTcc: StatusTcc.Finalizado);
+        using var _ = factory;
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{bancaId}/ata-pdf");
+
+        await AssertPdfValidoAsync(response);
+    }
+
+    [Fact]
+    public async Task BancaAprovada_ComAvaliadorExterno_RetornaPdf()
+    {
+        var (factory, bancaId) = await SemearBancaAsync(
+            notaFinal: 88.0m, statusTcc: StatusTcc.Finalizado, comAvaliadorExterno: true);
+        using var _ = factory;
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{bancaId}/ata-pdf");
+
+        await AssertPdfValidoAsync(response);
+    }
+
+    [Fact]
+    public async Task BancaReprovada_ComMotivo_RetornaPdf()
+    {
+        var (factory, bancaId) = await SemearBancaAsync(
+            notaFinal: 45.0m, statusTcc: StatusTcc.Reprovado,
+            motivoRejeicao: "Metodologia insuficiente para os objetivos propostos.",
+            comAvaliadorExterno: true);
+        using var _ = factory;
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{bancaId}/ata-pdf");
+
+        await AssertPdfValidoAsync(response);
+    }
+}

--- a/TccManager.Tests/Controllers/CoordenadorController_AtaRascunhoPdf_Tests.cs
+++ b/TccManager.Tests/Controllers/CoordenadorController_AtaRascunhoPdf_Tests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using TccManager.Api.Services.Email;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
+using TccManager.Tests.Services.Email;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração dos endpoints do Coordenador do rascunho (Etapa 2):
+/// GET /api/coordenador/banca/{idBanca}/ata-rascunho-pdf (download, 200/404/410) e
+/// POST /api/coordenador/banca/{idBanca}/membro-externo/{idMembroExterno}/reenviar-rascunho
+/// (revoga o token vigente — não deleta — gera um novo, e enfileira o e-mail dedicado).
+/// Usa FakeEmailQueue para capturar o e-mail de reenvio e extrair o novo token, validando
+/// ponta a ponta que o antigo passa a 404 e o novo a 200 no endpoint público.
+/// </summary>
+public class CoordenadorController_AtaRascunhoPdf_Tests
+{
+    private const int idCoordenador = 1;
+
+    private sealed class FactoryComFilaFake : WebRootIsolatedApiFactory
+    {
+        private readonly FakeEmailQueue _fila;
+        public FactoryComFilaFake(FakeEmailQueue fila) => _fila = fila;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IEmailQueue>();
+                services.AddSingleton<IEmailQueue>(_fila);
+            });
+        }
+    }
+
+    private sealed record Semeadura(int BancaId, int MembroExternoId);
+
+    private static async Task<Semeadura> SemearBancaComMembroAsync(
+        WebRootIsolatedApiFactory factory,
+        decimal? notaFinal = null,
+        StatusTcc statusTcc = StatusTcc.AguardandoDefesa)
+    {
+        using var context = factory.CriarContextoDireto();
+
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC Coordenador",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = statusTcc,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        var externo = new MembroExterno { Nome = "Externo", Email = "ext@empresa.com", Instituicao = "Empresa" };
+        context.MembrosExternos.Add(externo);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        await context.SaveChangesAsync();
+
+        return new Semeadura(banca.Id, externo.Id);
+    }
+
+    private static async Task<string> GerarTokenAsync(WebRootIsolatedApiFactory factory, int bancaId, int membroId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var tokenService = scope.ServiceProvider.GetRequiredService<IRascunhoAtaTokenService>();
+        return await tokenService.GerarTokenAsync(bancaId, membroId);
+    }
+
+    private static string ExtrairToken(string corpoHtml)
+    {
+        var match = Regex.Match(corpoHtml, "/api/rascunho-ata/([0-9a-f]{64})");
+        Assert.True(match.Success, "O corpo do e-mail de reenvio não contém um link com token de 64 hex.");
+        return match.Groups[1].Value;
+    }
+
+    // ── Download pelo Coordenador ─────────────────────────────────────
+
+    [Fact]
+    public async Task Download_BancaSemResultado_RetornaPdf()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaComMembroAsync(factory);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task Download_BancaInexistente_Retorna404()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync("/api/coordenador/banca/9999/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Download_ResultadoRegistrado_Retorna410()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaComMembroAsync(factory, notaFinal: 90m, statusTcc: StatusTcc.Finalizado);
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await client.GetAsync($"/api/coordenador/banca/{s.BancaId}/ata-rascunho-pdf");
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+    }
+
+    // ── Reenvio (RF-06) ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reenvio_RevogaTokenAntigo_EGeraNovoValido_EnfileirandoEmail()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+        var s = await SemearBancaComMembroAsync(factory);
+
+        // Token inicial (simula o emitido no agendamento) — válido no público antes do reenvio.
+        var tokenAntigo = await GerarTokenAsync(factory, s.BancaId, s.MembroExternoId);
+        var anon = factory.CreateClient();
+        Assert.Equal(HttpStatusCode.OK, (await anon.GetAsync($"/api/rascunho-ata/{tokenAntigo}")).StatusCode);
+
+        // Reenvio pelo Coordenador.
+        var coord = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var reenvio = await coord.PostAsync(
+            $"/api/coordenador/banca/{s.BancaId}/membro-externo/{s.MembroExternoId}/reenviar-rascunho", null);
+        Assert.Equal(HttpStatusCode.OK, reenvio.StatusCode);
+
+        // E-mail dedicado enfileirado para o membro externo.
+        var msg = Assert.Single(fila.Mensagens);
+        Assert.Equal("Novo link de acesso ao rascunho da ata", msg.Assunto);
+        Assert.Equal(new[] { "ext@empresa.com" }, msg.Destinatarios);
+
+        // Token antigo passa a inválido (404) imediatamente; o novo (extraído do e-mail) valida (200).
+        Assert.Equal(HttpStatusCode.NotFound, (await anon.GetAsync($"/api/rascunho-ata/{tokenAntigo}")).StatusCode);
+
+        var tokenNovo = ExtrairToken(msg.CorpoHtml);
+        Assert.NotEqual(tokenAntigo, tokenNovo);
+        Assert.Equal(HttpStatusCode.OK, (await anon.GetAsync($"/api/rascunho-ata/{tokenNovo}")).StatusCode);
+
+        // O token antigo foi REVOGADO, não deletado: histórico preservado, exatamente 1 ativo.
+        using var context = factory.CriarContextoDireto();
+        var linhas = context.RascunhoAtaTokens
+            .Where(t => t.BancaId == s.BancaId && t.MembroExternoId == s.MembroExternoId)
+            .ToList();
+        Assert.Equal(2, linhas.Count);
+        Assert.Single(linhas, t => t.RevokedAtUtc == null);
+    }
+
+    [Fact]
+    public async Task Reenvio_MembroNaoAvaliadorDaBanca_Retorna404()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+        var s = await SemearBancaComMembroAsync(factory);
+        var coord = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        // Membro externo inexistente / não vinculado a esta banca.
+        var response = await coord.PostAsync(
+            $"/api/coordenador/banca/{s.BancaId}/membro-externo/999999/reenviar-rascunho", null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Empty(fila.Mensagens);
+    }
+
+    [Fact]
+    public async Task Reenvio_ResultadoJaRegistrado_Retorna410()
+    {
+        var fila = new FakeEmailQueue();
+        using var factory = new FactoryComFilaFake(fila);
+        var s = await SemearBancaComMembroAsync(factory, notaFinal: 85m, statusTcc: StatusTcc.Finalizado);
+        var coord = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+
+        var response = await coord.PostAsync(
+            $"/api/coordenador/banca/{s.BancaId}/membro-externo/{s.MembroExternoId}/reenviar-rascunho", null);
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+        Assert.Empty(fila.Mensagens);
+    }
+}

--- a/TccManager.Tests/Controllers/CoordenadorController_BancasConcluidas_Tests.cs
+++ b/TccManager.Tests/Controllers/CoordenadorController_BancasConcluidas_Tests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Http.Json;
+using TccManager.Shared.DTOs;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração de GET /api/coordenador/bancas-concluidas (PagedResult&lt;BancaConcluidaDto&gt;).
+/// Verifica: filtro por NotaFinal != null (bancas pendentes não aparecem), derivação de
+/// Aprovado a partir de Tcc.Status == StatusTcc.Finalizado (e NÃO recalculado da nota),
+/// ordenação por DataHora desc e paginação — reaproveitando os padrões de asserção usados em
+/// Paginacao_Integracao_Tests.cs (Q3).
+/// </summary>
+public class CoordenadorController_BancasConcluidas_Tests
+{
+    private const int idCoordenador = 1;
+
+    // Pequeno wrapper para semear via o contexto direto da factory sem repetir boilerplate.
+    private sealed class AppDbContextSeeder
+    {
+        private readonly TccManager.Api.Data.AppDbContext _context;
+        private int _seq;
+        public AppDbContextSeeder(TccManager.Api.Data.AppDbContext context) => _context = context;
+
+        public async Task<int> AddBancaAsync(decimal? notaFinal, StatusTcc statusTcc, DateTime dataHora, string titulo)
+        {
+            _seq++;
+            var aluno = new Usuario { Nome = $"Aluno {_seq:D3}", Email = $"aluno{_seq}@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+            _context.Usuarios.Add(aluno);
+            await _context.SaveChangesAsync();
+
+            var tcc = new Tcc
+            {
+                Titulo = titulo,
+                Resumo = "Resumo",
+                AlunoId = aluno.Id,
+                Status = statusTcc,
+                DataCriacao = DateTime.UtcNow
+            };
+            _context.Tccs.Add(tcc);
+            await _context.SaveChangesAsync();
+
+            var banca = new Banca
+            {
+                TccId = tcc.Id,
+                DataHora = dataHora,
+                Local = "Sala",
+                NotaFinal = notaFinal
+            };
+            _context.Banca.Add(banca);
+            await _context.SaveChangesAsync();
+            return banca.Id;
+        }
+    }
+
+    [Fact]
+    public async Task SoRetornaBancasComNotaFinal_NaoMisturaComPendentes()
+    {
+        var factory = new TccApiFactory();
+        using var _ = factory;
+        using (var context = factory.CriarContextoDireto())
+        {
+            var seeder = new AppDbContextSeeder(context);
+            await seeder.AddBancaAsync(80.0m, StatusTcc.Finalizado, DateTime.UtcNow.AddDays(-2), "Concluida A");
+            await seeder.AddBancaAsync(50.0m, StatusTcc.Reprovado, DateTime.UtcNow.AddDays(-1), "Concluida B");
+            // Pendente: sem NotaFinal — não deve aparecer.
+            await seeder.AddBancaAsync(null, StatusTcc.AguardandoDefesa, DateTime.UtcNow, "Pendente C");
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var response = await client.GetAsync("/api/coordenador/bancas-concluidas");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<BancaConcluidaDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(2, pagina!.TotalCount);
+        Assert.All(pagina.Items, dto => Assert.DoesNotContain("Pendente", dto.TccTitulo));
+    }
+
+    [Fact]
+    public async Task Aprovado_DerivaDoStatusFinalizado_NaoDaNota()
+    {
+        var factory = new TccApiFactory();
+        using var _ = factory;
+        int bancaNotaAltaReprovada, bancaNotaBaixaFinalizada;
+        using (var context = factory.CriarContextoDireto())
+        {
+            var seeder = new AppDbContextSeeder(context);
+            // Nota alta (>= qualquer limiar), mas Status Reprovado => Aprovado deve ser false.
+            bancaNotaAltaReprovada = await seeder.AddBancaAsync(95.0m, StatusTcc.Reprovado, DateTime.UtcNow.AddDays(-1), "Alta mas reprovada");
+            // Nota baixa, mas Status Finalizado => Aprovado deve ser true (segue o Status).
+            bancaNotaBaixaFinalizada = await seeder.AddBancaAsync(10.0m, StatusTcc.Finalizado, DateTime.UtcNow.AddDays(-2), "Baixa mas finalizada");
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var response = await client.GetAsync("/api/coordenador/bancas-concluidas?pageSize=100");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<BancaConcluidaDto>>();
+
+        Assert.NotNull(pagina);
+        var altaReprovada = pagina!.Items.Single(b => b.BancaId == bancaNotaAltaReprovada);
+        var baixaFinalizada = pagina.Items.Single(b => b.BancaId == bancaNotaBaixaFinalizada);
+
+        Assert.False(altaReprovada.Aprovado);
+        Assert.True(baixaFinalizada.Aprovado);
+    }
+
+    [Fact]
+    public async Task OrdenadasPorDataHoraDescendente()
+    {
+        var factory = new TccApiFactory();
+        using var _ = factory;
+        using (var context = factory.CriarContextoDireto())
+        {
+            var seeder = new AppDbContextSeeder(context);
+            await seeder.AddBancaAsync(70.0m, StatusTcc.Finalizado, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), "Mais antiga");
+            await seeder.AddBancaAsync(70.0m, StatusTcc.Finalizado, new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), "Mais recente");
+            await seeder.AddBancaAsync(70.0m, StatusTcc.Finalizado, new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc), "Intermediaria");
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var response = await client.GetAsync("/api/coordenador/bancas-concluidas");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<BancaConcluidaDto>>();
+
+        Assert.NotNull(pagina);
+        var datas = pagina!.Items.Select(i => i.DataHora).ToList();
+        Assert.Equal(datas.OrderByDescending(d => d).ToList(), datas);
+        Assert.Equal("Mais recente", pagina.Items.First().TccTitulo);
+    }
+
+    [Fact]
+    public async Task Paginacao_TotalCountRefleteTotal_ComPaginaParcial()
+    {
+        var factory = new TccApiFactory();
+        using var _ = factory;
+        using (var context = factory.CriarContextoDireto())
+        {
+            var seeder = new AppDbContextSeeder(context);
+            for (int i = 1; i <= 25; i++)
+                await seeder.AddBancaAsync(70.0m, StatusTcc.Finalizado, DateTime.UtcNow.AddDays(-i), $"Banca {i:D3}");
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var response = await client.GetAsync("/api/coordenador/bancas-concluidas?page=2&pageSize=10");
+
+        response.EnsureSuccessStatusCode();
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<BancaConcluidaDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(25, pagina!.TotalCount);
+        Assert.Equal(3, pagina.TotalPages);
+        Assert.Equal(2, pagina.CurrentPage);
+        Assert.Equal(10, pagina.Items.Count);
+    }
+
+    [Fact]
+    public async Task Paginacao_ValoresNaoNumericos_NaoRetornam400_UsamDefaults()
+    {
+        var factory = new TccApiFactory();
+        using var _ = factory;
+        using (var context = factory.CriarContextoDireto())
+        {
+            var seeder = new AppDbContextSeeder(context);
+            await seeder.AddBancaAsync(70.0m, StatusTcc.Finalizado, DateTime.UtcNow, "Banca X");
+        }
+
+        var client = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var response = await client.GetAsync("/api/coordenador/bancas-concluidas?page=abc&pageSize=xyz");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var pagina = await response.Content.ReadFromJsonAsync<PagedResult<BancaConcluidaDto>>();
+
+        Assert.NotNull(pagina);
+        Assert.Equal(PaginacaoQuery.DefaultPage, pagina!.CurrentPage);
+        Assert.Equal(PaginacaoQuery.DefaultPageSize, pagina.PageSize);
+        Assert.Equal(1, pagina.TotalCount);
+    }
+}

--- a/TccManager.Tests/Controllers/RascunhoAtaController_Tests.cs
+++ b/TccManager.Tests/Controllers/RascunhoAtaController_Tests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Integração do endpoint público GET /api/rascunho-ata/{token} através do pipeline HTTP
+/// (WebApplicationFactory + EF InMemory). Cobre: [AllowAnonymous] efetivo (sem cabeçalho de
+/// auth), token válido → 200 application/pdf (%PDF), token inexistente/revogado/expirado →
+/// 404 genérico, e ResultadoRegistrado → 410 Gone.
+/// </summary>
+public class RascunhoAtaController_Tests
+{
+    private sealed record Semeadura(int BancaId, int MembroExternoId);
+
+    private static async Task<Semeadura> SemearBancaComMembroAsync(
+        WebRootIsolatedApiFactory factory,
+        DateTime dataHora,
+        decimal? notaFinal = null)
+    {
+        using var context = factory.CriarContextoDireto();
+
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC Público",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = notaFinal == null ? StatusTcc.AguardandoDefesa : StatusTcc.Finalizado,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = dataHora, Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        var externo = new MembroExterno { Nome = "Externo", Email = "ext@empresa.com", Instituicao = "Empresa" };
+        context.MembrosExternos.Add(externo);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        await context.SaveChangesAsync();
+
+        return new Semeadura(banca.Id, externo.Id);
+    }
+
+    private static async Task<string> GerarTokenAsync(WebRootIsolatedApiFactory factory, int bancaId, int membroId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var tokenService = scope.ServiceProvider.GetRequiredService<IRascunhoAtaTokenService>();
+        return await tokenService.GerarTokenAsync(bancaId, membroId);
+    }
+
+    private static async Task AssertPdfValidoAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Assert.True(bytes.Length > 100, "PDF retornado é suspeito de estar vazio/truncado.");
+        Assert.True(
+            bytes.Length >= 4 && bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46,
+            "O corpo da resposta não começa com a assinatura %PDF.");
+    }
+
+    [Fact]
+    public async Task TokenValido_SemAutenticacao_RetornaPdf()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var semeadura = await SemearBancaComMembroAsync(factory, DateTime.UtcNow.AddDays(3));
+        var token = await GerarTokenAsync(factory, semeadura.BancaId, semeadura.MembroExternoId);
+
+        // CreateClient() puro: nenhum cabeçalho X-Test-UserId → prova o [AllowAnonymous].
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/api/rascunho-ata/{token}");
+
+        await AssertPdfValidoAsync(response);
+    }
+
+    [Fact]
+    public async Task TokenInexistente_Retorna404()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/api/rascunho-ata/{new string('0', 64)}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TokenRevogado_Retorna404()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var semeadura = await SemearBancaComMembroAsync(factory, DateTime.UtcNow.AddDays(3));
+        var token = await GerarTokenAsync(factory, semeadura.BancaId, semeadura.MembroExternoId);
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var tokenService = scope.ServiceProvider.GetRequiredService<IRascunhoAtaTokenService>();
+            await tokenService.RevogarTokenAtualAsync(semeadura.BancaId, semeadura.MembroExternoId);
+        }
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/api/rascunho-ata/{token}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TokenExpiradoPorData_Retorna404()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var semeadura = await SemearBancaComMembroAsync(factory, DateTime.UtcNow.AddMinutes(-10));
+        var token = await GerarTokenAsync(factory, semeadura.BancaId, semeadura.MembroExternoId);
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/api/rascunho-ata/{token}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResultadoRegistrado_ComBancaNoFuturo_Retorna410()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var semeadura = await SemearBancaComMembroAsync(factory, DateTime.UtcNow.AddDays(3), notaFinal: 88m);
+        var token = await GerarTokenAsync(factory, semeadura.BancaId, semeadura.MembroExternoId);
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync($"/api/rascunho-ata/{token}");
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+    }
+}

--- a/TccManager.Tests/Controllers/RascunhoAta_410Gone_Tests.cs
+++ b/TccManager.Tests/Controllers/RascunhoAta_410Gone_Tests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using TccManager.Tests.Fixtures;
+using Xunit;
+
+namespace TccManager.Tests.Controllers;
+
+/// <summary>
+/// Regra RNF-03 (Etapa 2): uma vez que Banca.NotaFinal != null, os TRÊS pontos de acesso ao
+/// rascunho (Coordenador, avaliador interno vinculado e público via token) devem responder
+/// 410 Gone, independentemente de o token/banca já ter expirado por data. Cobre tanto o
+/// cenário com a banca no futuro quanto o cenário realista pós-defesa (DataHora no passado).
+/// RascunhoAtaTokenService.ValidarAsync checa NotaFinal antes da expiração por data para
+/// garantir essa convergência.
+/// </summary>
+public class RascunhoAta_410Gone_Tests
+{
+    private const int idCoordenador = 1;
+
+    private sealed record Semeadura(int BancaId, int AvaliadorId, int MembroExternoId);
+
+    private static async Task<Semeadura> SemearBancaAsync(
+        WebRootIsolatedApiFactory factory,
+        DateTime dataHora,
+        decimal notaFinal)
+    {
+        using var context = factory.CriarContextoDireto();
+
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var avaliador = new Usuario { Nome = "Avaliador", Email = "aval@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador, avaliador);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC 410",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = StatusTcc.Finalizado,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = dataHora, Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        var externo = new MembroExterno { Nome = "Externo", Email = "ext@empresa.com", Instituicao = "Empresa" };
+        context.MembrosExternos.Add(externo);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, ProfessorId = avaliador.Id });
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        await context.SaveChangesAsync();
+
+        return new Semeadura(banca.Id, avaliador.Id, externo.Id);
+    }
+
+    private static async Task<string> GerarTokenAsync(WebRootIsolatedApiFactory factory, int bancaId, int membroId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var tokenService = scope.ServiceProvider.GetRequiredService<IRascunhoAtaTokenService>();
+        return await tokenService.GerarTokenAsync(bancaId, membroId);
+    }
+
+    [Fact]
+    public async Task ComResultado_BancaNoFuturo_TresPontosDeAcesso_Retornam410()
+    {
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory, DateTime.UtcNow.AddDays(3), notaFinal: 88m);
+        var token = await GerarTokenAsync(factory, s.BancaId, s.MembroExternoId);
+
+        var coord = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var aval = factory.CreateClientAutenticado(s.AvaliadorId, "Professor");
+        var anon = factory.CreateClient();
+
+        var respCoord = await coord.GetAsync($"/api/coordenador/banca/{s.BancaId}/ata-rascunho-pdf");
+        var respAval = await aval.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf");
+        var respPublico = await anon.GetAsync($"/api/rascunho-ata/{token}");
+
+        Assert.Equal(HttpStatusCode.Gone, respCoord.StatusCode);
+        Assert.Equal(HttpStatusCode.Gone, respAval.StatusCode);
+        Assert.Equal(HttpStatusCode.Gone, respPublico.StatusCode);
+    }
+
+    [Fact]
+    public async Task ComResultado_PosDefesa_TresPontosDeAcesso_Retornam410()
+    {
+        // Cenário realista: resultado registrado após a defesa (DataHora no passado).
+        // Os três pontos de acesso devem convergir em 410, não apenas Coordenador/avaliador.
+        using var factory = new WebRootIsolatedApiFactory();
+        var s = await SemearBancaAsync(factory, DateTime.UtcNow.AddDays(-1), notaFinal: 88m);
+        var token = await GerarTokenAsync(factory, s.BancaId, s.MembroExternoId);
+
+        var coord = factory.CreateClientAutenticado(idCoordenador, "Coordenador");
+        var aval = factory.CreateClientAutenticado(s.AvaliadorId, "Professor");
+        var anon = factory.CreateClient();
+
+        Assert.Equal(HttpStatusCode.Gone, (await coord.GetAsync($"/api/coordenador/banca/{s.BancaId}/ata-rascunho-pdf")).StatusCode);
+        Assert.Equal(HttpStatusCode.Gone, (await aval.GetAsync($"/api/avaliador/banca/{s.BancaId}/ata-rascunho-pdf")).StatusCode);
+        Assert.Equal(HttpStatusCode.Gone, (await anon.GetAsync($"/api/rascunho-ata/{token}")).StatusCode);
+    }
+}

--- a/TccManager.Tests/Services/Notifications/TccNotificationServiceTests.cs
+++ b/TccManager.Tests/Services/Notifications/TccNotificationServiceTests.cs
@@ -1,8 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using TccManager.Api.Configuration;
 using TccManager.Api.Data;
 using TccManager.Api.Services.Email;
 using TccManager.Api.Services.Notifications;
+using TccManager.Api.Services.Pdf;
 using TccManager.Shared.Enums;
 using TccManager.Shared.Models;
 using TccManager.Tests.Services.Email;
@@ -32,7 +35,9 @@ public class TccNotificationServiceTests
             context,
             new FileEmailTemplateRenderer(),
             queue,
-            NullLogger<TccNotificationService>.Instance);
+            NullLogger<TccNotificationService>.Instance,
+            new RascunhoAtaTokenService(context),
+            Options.Create(new AppUrlsOptions()));
 
     private static Usuario NovoUsuario(int id, string nome, string email, TipoUsuario tipo, bool ativo = true)
         => new() { Id = id, Nome = nome, Email = email, SenhaHash = "x", Tipo = tipo, Ativo = ativo };
@@ -289,6 +294,109 @@ public class TccNotificationServiceTests
         await context.SaveChangesAsync();
 
         await CriarServico(context, queue).NotificarPropostaAprovadaAsync(1);
+
+        Assert.Empty(queue.Mensagens);
+    }
+
+    // ── BancaAgendada — geração de token por membro externo (Etapa 2) ──
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_GeraTokenPorMembroExterno_ComLinkNoEmailDele()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.Usuarios.Add(NovoUsuario(21, "Avaliador Interno", "interno@teste.com", TipoUsuario.Professor));
+        context.MembrosExternos.Add(new MembroExterno { Id = 5, Nome = "Externo", Email = "externo@empresa.com", Instituicao = "Empresa" });
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1, ProfessorId = 21 });
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 2, BancaId = 1, MembroExternoId = 5 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        // Exatamente um token ativo persistido para o par (Banca 1, MembroExterno 5).
+        var tokens = context.RascunhoAtaTokens.Where(t => t.BancaId == 1 && t.MembroExternoId == 5).ToList();
+        var tokenAtivo = Assert.Single(tokens);
+        Assert.Null(tokenAtivo.RevokedAtUtc);
+
+        // Só o e-mail do membro externo carrega o link com token; internos/aluno/orientador não.
+        var msgExterno = queue.Mensagens.Single(m => m.Destinatarios.Contains("externo@empresa.com"));
+        Assert.Matches("/api/rascunho-ata/[0-9a-f]{64}", msgExterno.CorpoHtml);
+
+        var msgInterno = queue.Mensagens.Single(m => m.Destinatarios.Contains("interno@teste.com"));
+        Assert.DoesNotContain("rascunho-ata", msgInterno.CorpoHtml);
+        Assert.Contains("/avaliador/convites", msgInterno.CorpoHtml);
+
+        var msgAluno = queue.Mensagens.Single(m => m.Destinatarios.Contains("aluno@teste.com"));
+        Assert.DoesNotContain("rascunho-ata", msgAluno.CorpoHtml);
+    }
+
+    [Fact]
+    public async Task NotificarBancaAgendadaAsync_NaoVazaTokenDeUmMembroNoEmailDeOutro()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.Usuarios.Add(NovoUsuario(10, "Aluno", "aluno@teste.com", TipoUsuario.Aluno));
+        context.Usuarios.Add(NovoUsuario(20, "Orientador", "orient@teste.com", TipoUsuario.Professor));
+        context.MembrosExternos.Add(new MembroExterno { Id = 5, Nome = "Externo A", Email = "extA@empresa.com", Instituicao = "Empresa" });
+        context.MembrosExternos.Add(new MembroExterno { Id = 6, Nome = "Externo B", Email = "extB@empresa.com", Instituicao = "Empresa" });
+        context.Tccs.Add(new Tcc { Id = 1, Titulo = "TCC A", Resumo = "r", AlunoId = 10, OrientadorId = 20, Status = StatusTcc.AguardandoDefesa });
+
+        var banca = new Banca { Id = 1, TccId = 1, DataHora = DateTime.UtcNow.AddDays(3), Local = "Sala 1" };
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 1, BancaId = 1, MembroExternoId = 5 });
+        banca.Avaliadores.Add(new BancaAvaliador { Id = 2, BancaId = 1, MembroExternoId = 6 });
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        await CriarServico(context, queue).NotificarBancaAgendadaAsync(1);
+
+        var msgA = queue.Mensagens.Single(m => m.Destinatarios.Contains("extA@empresa.com"));
+        var msgB = queue.Mensagens.Single(m => m.Destinatarios.Contains("extB@empresa.com"));
+
+        var tokenA = System.Text.RegularExpressions.Regex.Match(msgA.CorpoHtml, "/api/rascunho-ata/([0-9a-f]{64})").Groups[1].Value;
+        var tokenB = System.Text.RegularExpressions.Regex.Match(msgB.CorpoHtml, "/api/rascunho-ata/([0-9a-f]{64})").Groups[1].Value;
+
+        Assert.NotEqual(string.Empty, tokenA);
+        Assert.NotEqual(tokenA, tokenB);
+        // O token de A não aparece no e-mail de B e vice-versa (cada um recebe só o seu).
+        Assert.DoesNotContain(tokenA, msgB.CorpoHtml);
+        Assert.DoesNotContain(tokenB, msgA.CorpoHtml);
+    }
+
+    // ── ReenvioRascunho (Etapa 2) ─────────────────────────────────────
+
+    [Fact]
+    public async Task NotificarReenvioRascunhoAsync_EnfileiraEmailDedicadoParaOMembro_ComLink()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        context.MembrosExternos.Add(new MembroExterno { Id = 5, Nome = "Externo", Email = "externo@empresa.com", Instituicao = "Empresa" });
+        await context.SaveChangesAsync();
+
+        var tokenBruto = new string('a', 64);
+        await CriarServico(context, queue).NotificarReenvioRascunhoAsync(1, 5, tokenBruto);
+
+        var msg = Assert.Single(queue.Mensagens);
+        Assert.Equal("Novo link de acesso ao rascunho da ata", msg.Assunto);
+        Assert.Equal(new[] { "externo@empresa.com" }, msg.Destinatarios);
+        Assert.Contains($"/api/rascunho-ata/{tokenBruto}", msg.CorpoHtml);
+    }
+
+    [Fact]
+    public async Task NotificarReenvioRascunhoAsync_MembroInexistente_NaoEnfileiraNemLanca()
+    {
+        using var context = CriarContexto();
+        var queue = new FakeEmailQueue();
+
+        await CriarServico(context, queue).NotificarReenvioRascunhoAsync(1, 999, new string('a', 64));
 
         Assert.Empty(queue.Mensagens);
     }

--- a/TccManager.Tests/Services/Pdf/AtaPdfServiceRascunhoTests.cs
+++ b/TccManager.Tests/Services/Pdf/AtaPdfServiceRascunhoTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QuestPDF.Infrastructure;
+using TccManager.Api.Data;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Services.Pdf;
+
+/// <summary>
+/// Testes de unidade do fluxo RASCUNHO do <see cref="AtaPdfService"/> (N2 Etapa 2):
+/// <c>GerarAtaRascunhoAsync</c> resolve BancaNaoEncontrada (404), ResultadoJaRegistrado
+/// (410, quando NotaFinal != null) e Sucesso (PDF %PDF) enquanto NotaFinal == null,
+/// incluindo a composição com avaliador interno + externo. A verificação de que o PDF
+/// rascunho OMITE nota/assinaturas não é feita por parsing de bytes (PDF QuestPDF é
+/// comprimido — mesmo motivo pelo qual os testes da Etapa 1 só validam a assinatura %PDF);
+/// a omissão condicional é coberta indiretamente pela lógica de AtaPdfDocument e sinalizada
+/// como não coberta por asserção de conteúdo ao qa-agent.
+/// </summary>
+public class AtaPdfServiceRascunhoTests
+{
+    static AtaPdfServiceRascunhoTests()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    private static AppDbContext NovoContexto()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static AtaPdfService NovoServico(AppDbContext context)
+    {
+        var options = Options.Create(new AtaInstitucionalOptions
+        {
+            Instituicao = "Instituto de Teste",
+            Curso = "Ciência da Computação"
+        });
+        return new AtaPdfService(context, options);
+    }
+
+    private static async Task<int> SemearBancaAsync(
+        AppDbContext context,
+        decimal? notaFinal,
+        StatusTcc statusTcc,
+        bool comAvaliadorExterno = false)
+    {
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var avaliadorInterno = new Usuario { Nome = "Avaliador Interno", Email = "aval@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador, avaliadorInterno);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC Rascunho",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = statusTcc,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = DateTime.UtcNow.AddDays(2), Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, ProfessorId = avaliadorInterno.Id });
+
+        if (comAvaliadorExterno)
+        {
+            var externo = new MembroExterno { Nome = "Externa", Email = "externa@outra.edu", Instituicao = "Universidade Externa" };
+            context.MembrosExternos.Add(externo);
+            await context.SaveChangesAsync();
+            context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        }
+
+        await context.SaveChangesAsync();
+        return banca.Id;
+    }
+
+    private static void AssertAssinaturaPdf(byte[] bytes)
+    {
+        Assert.True(bytes.Length > 100, "PDF rascunho é suspeito de estar vazio/truncado.");
+        Assert.True(
+            bytes.Length >= 4 && bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46,
+            "Os bytes gerados não começam com a assinatura %PDF.");
+    }
+
+    [Fact]
+    public async Task GerarAtaRascunho_BancaInexistente_RetornaBancaNaoEncontrada()
+    {
+        using var context = NovoContexto();
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaRascunhoAsync(999);
+
+        Assert.Equal(AtaPdfResultadoStatus.BancaNaoEncontrada, resultado.Status);
+        Assert.Null(resultado.PdfBytes);
+    }
+
+    [Fact]
+    public async Task GerarAtaRascunho_ResultadoJaRegistrado_Retorna410_SemPdf()
+    {
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(context, notaFinal: 90m, statusTcc: StatusTcc.Finalizado);
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaRascunhoAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.ResultadoJaRegistrado, resultado.Status);
+        Assert.Null(resultado.PdfBytes);
+    }
+
+    [Fact]
+    public async Task GerarAtaRascunho_SemNota_GeraPdf()
+    {
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(context, notaFinal: null, statusTcc: StatusTcc.AguardandoDefesa);
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaRascunhoAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.Sucesso, resultado.Status);
+        Assert.NotNull(resultado.PdfBytes);
+        AssertAssinaturaPdf(resultado.PdfBytes!);
+    }
+
+    [Fact]
+    public async Task GerarAtaRascunho_SemNota_ComAvaliadorInternoEExterno_GeraPdf()
+    {
+        // Exercita os dois ramos de resolução do avaliador (Professor + MembroExterno) no
+        // rascunho — um mapeamento incorreto lançaria NRE antes de gerar o PDF.
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(
+            context, notaFinal: null, statusTcc: StatusTcc.AguardandoDefesa, comAvaliadorExterno: true);
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaRascunhoAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.Sucesso, resultado.Status);
+        AssertAssinaturaPdf(resultado.PdfBytes!);
+    }
+}

--- a/TccManager.Tests/Services/Pdf/AtaPdfServiceTests.cs
+++ b/TccManager.Tests/Services/Pdf/AtaPdfServiceTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using QuestPDF.Infrastructure;
+using TccManager.Api.Data;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Services.Pdf;
+
+/// <summary>
+/// Testes de unidade do <see cref="AtaPdfService"/> exercitando a lógica de orquestração
+/// diretamente sobre um <see cref="AppDbContext"/> InMemory, sem o pipeline HTTP. O foco é a
+/// resolução de status (banca inexistente/ resultado não registrado/ sucesso) e a resolução
+/// do polimorfismo do avaliador (Professor interno vs. MembroExterno), que só é exercida de
+/// ponta a ponta quando o PDF chega a ser gerado — se o mapeamento escolhesse o ramo errado,
+/// o acesso a <c>Professor!</c> / <c>MembroExterno!</c> lançaria NullReferenceException aqui.
+/// </summary>
+public class AtaPdfServiceTests
+{
+    static AtaPdfServiceTests()
+    {
+        // Em teste de unidade não passamos pelo PdfSetup.AddAtaPdf (que configura a licença);
+        // sem isso o GeneratePdf() do QuestPDF lançaria por falta de licença aceita.
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    private static AppDbContext NovoContexto()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static AtaPdfService NovoServico(AppDbContext context)
+    {
+        var options = Options.Create(new AtaInstitucionalOptions
+        {
+            Instituicao = "Instituto de Teste",
+            Curso = "Ciência da Computação"
+        });
+        return new AtaPdfService(context, options);
+    }
+
+    private static async Task<int> SemearBancaAsync(
+        AppDbContext context,
+        decimal? notaFinal,
+        StatusTcc statusTcc,
+        string? motivoRejeicao = null,
+        bool comAvaliadorExterno = false)
+    {
+        var aluno = new Usuario { Nome = "Aluno da Silva", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Prof. Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        var avaliadorInterno = new Usuario { Nome = "Prof. Avaliador Interno", Email = "aval@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador, avaliadorInterno);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "Um Título de TCC",
+            Resumo = "Resumo",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = statusTcc,
+            MotivoRejeicao = motivoRejeicao,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca
+        {
+            TccId = tcc.Id,
+            DataHora = DateTime.UtcNow.AddDays(-1),
+            Local = "Auditório 1",
+            NotaFinal = notaFinal
+        };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, ProfessorId = avaliadorInterno.Id });
+
+        if (comAvaliadorExterno)
+        {
+            var externo = new MembroExterno { Nome = "Dra. Externa", Email = "externa@outra.edu", Instituicao = "Universidade Externa" };
+            context.MembrosExternos.Add(externo);
+            await context.SaveChangesAsync();
+            context.BancaAvaliadores.Add(new BancaAvaliador { BancaId = banca.Id, MembroExternoId = externo.Id });
+        }
+
+        await context.SaveChangesAsync();
+        return banca.Id;
+    }
+
+    [Fact]
+    public async Task GerarAtaFinal_BancaInexistente_RetornaBancaNaoEncontrada_SemPdf()
+    {
+        using var context = NovoContexto();
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaFinalAsync(999);
+
+        Assert.Equal(AtaPdfResultadoStatus.BancaNaoEncontrada, resultado.Status);
+        Assert.Null(resultado.PdfBytes);
+    }
+
+    [Fact]
+    public async Task GerarAtaFinal_SemNotaFinal_RetornaResultadoNaoRegistrado_SemPdf()
+    {
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(context, notaFinal: null, statusTcc: StatusTcc.AguardandoDefesa);
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaFinalAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.ResultadoNaoRegistrado, resultado.Status);
+        Assert.Null(resultado.PdfBytes);
+    }
+
+    [Fact]
+    public async Task GerarAtaFinal_Aprovado_ComAvaliadorInternoEExterno_GeraPdf()
+    {
+        // Exercita os DOIS ramos da resolução do avaliador (Professor + MembroExterno)
+        // na mesma banca; um mapeamento incorreto lançaria NRE antes de gerar o PDF.
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(
+            context, notaFinal: 85.0m, statusTcc: StatusTcc.Finalizado, comAvaliadorExterno: true);
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaFinalAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.Sucesso, resultado.Status);
+        Assert.NotNull(resultado.PdfBytes);
+        AssertAssinaturaPdf(resultado.PdfBytes!);
+    }
+
+    [Fact]
+    public async Task GerarAtaFinal_Reprovado_ComMotivo_GeraPdf()
+    {
+        using var context = NovoContexto();
+        var bancaId = await SemearBancaAsync(
+            context, notaFinal: 40.0m, statusTcc: StatusTcc.Reprovado,
+            motivoRejeicao: "Não atingiu os requisitos mínimos.");
+        var servico = NovoServico(context);
+
+        var resultado = await servico.GerarAtaFinalAsync(bancaId);
+
+        Assert.Equal(AtaPdfResultadoStatus.Sucesso, resultado.Status);
+        Assert.NotNull(resultado.PdfBytes);
+        AssertAssinaturaPdf(resultado.PdfBytes!);
+    }
+
+    private static void AssertAssinaturaPdf(byte[] bytes)
+    {
+        Assert.True(bytes.Length > 100, "PDF gerado é suspeito de estar vazio/truncado.");
+        Assert.True(
+            bytes.Length >= 4 && bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46,
+            "Os bytes gerados não começam com a assinatura %PDF.");
+    }
+}

--- a/TccManager.Tests/Services/Pdf/RascunhoAtaTokenServiceTests.cs
+++ b/TccManager.Tests/Services/Pdf/RascunhoAtaTokenServiceTests.cs
@@ -1,0 +1,262 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using TccManager.Api.Data;
+using TccManager.Api.Services.Pdf;
+using TccManager.Shared.Enums;
+using TccManager.Shared.Models;
+using Xunit;
+
+namespace TccManager.Tests.Services.Pdf;
+
+/// <summary>
+/// Testes de unidade do <see cref="RascunhoAtaTokenService"/> (N2 Etapa 2) diretamente
+/// sobre um <see cref="AppDbContext"/> InMemory, sem o pipeline HTTP. Cobrem: geração
+/// (CSPRNG hex 64, apenas o hash é persistido, ExpiresAtUtc = Banca.DataHora), validação
+/// (Valido / Invalido para inexistente/revogado/expirado / ResultadoRegistrado para 410),
+/// revogação isolada e a invariante "no máximo 1 token ativo por par".
+///
+/// LIMITAÇÃO conhecida (ver docs/dados, §3.1/§8): o provider EF Core InMemory NÃO aplica o
+/// índice único filtrado UX_rascunho_ata_tokens_Banca_Membro_Ativo. A garantia de "1 token
+/// ativo por par" é aqui exercitada apenas no nível de código (GerarTokenAsync revoga o
+/// vigente antes de inserir). O enforcement declarativo no banco (falha de constraint em
+/// corrida concorrente) só seria verificável com SQL Server real — fica sinalizado ao qa-agent.
+/// </summary>
+public class RascunhoAtaTokenServiceTests
+{
+    private static AppDbContext NovoContexto()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<Banca> SemearBancaAsync(
+        AppDbContext context,
+        DateTime dataHora,
+        decimal? notaFinal = null)
+    {
+        var aluno = new Usuario { Nome = "Aluno", Email = "aluno@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Aluno, Ativo = true };
+        var orientador = new Usuario { Nome = "Orientador", Email = "orient@teste.com", SenhaHash = "x", Tipo = TipoUsuario.Professor, Ativo = true };
+        context.Usuarios.AddRange(aluno, orientador);
+        await context.SaveChangesAsync();
+
+        var tcc = new Tcc
+        {
+            Titulo = "TCC Token",
+            Resumo = "r",
+            AlunoId = aluno.Id,
+            OrientadorId = orientador.Id,
+            Status = notaFinal == null ? StatusTcc.AguardandoDefesa : StatusTcc.Finalizado,
+            DataCriacao = DateTime.UtcNow
+        };
+        context.Tccs.Add(tcc);
+        await context.SaveChangesAsync();
+
+        var banca = new Banca { TccId = tcc.Id, DataHora = dataHora, Local = "Sala 1", NotaFinal = notaFinal };
+        context.Banca.Add(banca);
+        await context.SaveChangesAsync();
+
+        return banca;
+    }
+
+    private static async Task<int> SemearMembroExternoAsync(AppDbContext context)
+    {
+        var membro = new MembroExterno { Nome = "Externo", Email = "ext@empresa.com", Instituicao = "Empresa" };
+        context.MembrosExternos.Add(membro);
+        await context.SaveChangesAsync();
+        return membro.Id;
+    }
+
+    private static string CalcularHashEsperado(string valor) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(valor))).ToLowerInvariant();
+
+    // ── Geração ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GerarTokenAsync_RetornaValorBrutoHex64Minusculo()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        var token = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        Assert.Equal(64, token.Length);
+        Assert.Matches("^[0-9a-f]{64}$", token);
+    }
+
+    [Fact]
+    public async Task GerarTokenAsync_DoisTokens_SaoDiferentes()
+    {
+        // CSPRNG (não Guid/sequencial): duas emissões geram valores distintos e imprevisíveis.
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        var token1 = await servico.GerarTokenAsync(banca.Id, membroId);
+        var token2 = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        Assert.NotEqual(token1, token2);
+    }
+
+    [Fact]
+    public async Task GerarTokenAsync_PersisteApenasOHash_NuncaOValorBruto()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        var tokenBruto = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        var linha = await context.RascunhoAtaTokens.SingleAsync();
+        Assert.NotEqual(tokenBruto, linha.TokenHash);
+        Assert.Equal(CalcularHashEsperado(tokenBruto), linha.TokenHash);
+        // Nenhuma coluna carrega o valor bruto: a única representação persistida é o hash.
+        Assert.DoesNotContain(context.RascunhoAtaTokens, t => t.TokenHash == tokenBruto);
+    }
+
+    [Fact]
+    public async Task GerarTokenAsync_ExpiresAtUtc_IgualBancaDataHora()
+    {
+        using var context = NovoContexto();
+        var dataHora = new DateTime(2027, 5, 10, 14, 30, 0, DateTimeKind.Utc);
+        var banca = await SemearBancaAsync(context, dataHora);
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        await servico.GerarTokenAsync(banca.Id, membroId);
+
+        var linha = await context.RascunhoAtaTokens.SingleAsync();
+        Assert.Equal(dataHora, linha.ExpiresAtUtc);
+        Assert.Equal(banca.Id, linha.BancaId);
+        Assert.Equal(membroId, linha.MembroExternoId);
+        Assert.Null(linha.RevokedAtUtc);
+    }
+
+    [Fact]
+    public async Task GerarTokenAsync_BancaInexistente_Lanca()
+    {
+        using var context = NovoContexto();
+        var servico = new RascunhoAtaTokenService(context);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => servico.GerarTokenAsync(9999, 1));
+    }
+
+    // ── Validação ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidarAsync_TokenValido_RetornaValidoComBancaId()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+        var token = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        var validacao = await servico.ValidarAsync(token);
+
+        Assert.Equal(RascunhoTokenValidacaoStatus.Valido, validacao.Status);
+        Assert.Equal(banca.Id, validacao.BancaId);
+    }
+
+    [Fact]
+    public async Task ValidarAsync_TokenInexistente_RetornaInvalido()
+    {
+        using var context = NovoContexto();
+        var servico = new RascunhoAtaTokenService(context);
+
+        var validacao = await servico.ValidarAsync(new string('0', 64));
+
+        Assert.Equal(RascunhoTokenValidacaoStatus.Invalido, validacao.Status);
+    }
+
+    [Fact]
+    public async Task ValidarAsync_TokenRevogado_RetornaInvalido()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+        var token = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        await servico.RevogarTokenAtualAsync(banca.Id, membroId);
+
+        var validacao = await servico.ValidarAsync(token);
+        Assert.Equal(RascunhoTokenValidacaoStatus.Invalido, validacao.Status);
+    }
+
+    [Fact]
+    public async Task ValidarAsync_TokenExpiradoPorData_RetornaInvalido()
+    {
+        // Banca no passado: UtcNow >= DataHora → token expirado por data (resposta genérica).
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddMinutes(-5));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+        var token = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        var validacao = await servico.ValidarAsync(token);
+
+        Assert.Equal(RascunhoTokenValidacaoStatus.Invalido, validacao.Status);
+    }
+
+    [Fact]
+    public async Task ValidarAsync_ResultadoRegistrado_RetornaResultadoRegistrado()
+    {
+        // NotaFinal preenchida + banca ainda no futuro (não expirada por data): 410 (RNF-03).
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3), notaFinal: 88m);
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+        var token = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        var validacao = await servico.ValidarAsync(token);
+
+        Assert.Equal(RascunhoTokenValidacaoStatus.ResultadoRegistrado, validacao.Status);
+        Assert.Equal(banca.Id, validacao.BancaId);
+    }
+
+    // ── Revogação / invariante de token ativo ─────────────────────────
+
+    [Fact]
+    public async Task GerarTokenAsync_Reemissao_RevogaOAnterior_MantendoNoMaximoUmAtivo()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        var token1 = await servico.GerarTokenAsync(banca.Id, membroId);
+        var token2 = await servico.GerarTokenAsync(banca.Id, membroId);
+
+        // O antigo passa a INVÁLIDO (revogado, não deletado); o novo é o único válido.
+        Assert.Equal(RascunhoTokenValidacaoStatus.Invalido, (await servico.ValidarAsync(token1)).Status);
+        Assert.Equal(RascunhoTokenValidacaoStatus.Valido, (await servico.ValidarAsync(token2)).Status);
+
+        var linhas = await context.RascunhoAtaTokens
+            .Where(t => t.BancaId == banca.Id && t.MembroExternoId == membroId)
+            .ToListAsync();
+        Assert.Equal(2, linhas.Count); // ambos preservados no histórico
+        Assert.Single(linhas, t => t.RevokedAtUtc == null); // no máximo 1 ativo
+    }
+
+    [Fact]
+    public async Task RevogarTokenAtualAsync_SemTokenAtivo_NaoLanca()
+    {
+        using var context = NovoContexto();
+        var banca = await SemearBancaAsync(context, DateTime.UtcNow.AddDays(3));
+        var membroId = await SemearMembroExternoAsync(context);
+        var servico = new RascunhoAtaTokenService(context);
+
+        // Nenhum token gerado ainda: operação idempotente, sem exceção.
+        await servico.RevogarTokenAtualAsync(banca.Id, membroId);
+
+        Assert.Empty(context.RascunhoAtaTokens);
+    }
+}


### PR DESCRIPTION
## Summary
- Etapa 1: geração de PDF da ata de defesa via QuestPDF, endpoint `ata-pdf` para o Coordenador, listagem paginada de bancas concluídas.
- Etapa 2: PDF rascunho pré-defesa (sem nota/assinaturas), acesso do Coordenador, avaliador interno vinculado à banca e membro externo via token opaco enviado por e-mail no agendamento (CSPRNG + hash-only, expiração pela data da banca, revogação no reenvio, bloqueio 410 Gone após registro do resultado nos três pontos de acesso).
- Correção de segurança: token bruto do rascunho redigido em logs de rate limiting e de exceção (não vaza em claro).

## Test plan
- [x] `dotnet build` sem erros (2 warnings pré-existentes não relacionados)
- [x] `dotnet test TccManager.Tests`: 239/239 aprovados
- [x] Revisão de segurança dedicada (achado Média corrigido antes do merge)
- [x] QA ponta a ponta aprovado
- [x] Teste manual em navegador (Etapa 1): login, download de PDF da ata, conteúdo validado
- [x] Confirmar índice único filtrado de `RascunhoAtaToken` em SQL Server real (não verificável no provider InMemory) — backlog #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)