### PR TITLE
ci: dispara CI e CodeQL tambem na branch dev (homologacao)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     # roda toda segunda-feira às 08:00 UTC, além dos push/PR acima
     - cron: '0 8 * * 1'


### PR DESCRIPTION
## Summary
- `ci.yml` e `codeql.yml` passam a disparar tambem em push/PR para a branch `dev` (ambiente de homologacao), alem de `main`.
- `sonarcloud.yml` nao foi alterado: o plano Free do SonarQube Cloud so cobre analise continua da branch `main` (branch analysis fica restrito aos planos Team/Enterprise).

## Test plan
- [ ] Confirmar que o workflow CI dispara ao dar push/abrir PR na branch `dev`
- [ ] Confirmar que o workflow CodeQL dispara ao dar push/abrir PR na branch `dev`
- [ ] Confirmar que `main` continua dispersando os workflows normalmente (sem regressao)