### PR TITLE
fix: dropdown de enum mostrava valor numerico em vez do texto

### DIFF
--- a/TccManager.Client/Pages/Admin/FormUsuario.razor
+++ b/TccManager.Client/Pages/Admin/FormUsuario.razor
@@ -57,7 +57,7 @@
 
                     <RadzenColumn SizeMD="6" SizeXS="12">
                         <RadzenFormField Text="Nível de Acesso" Variant="Variant.Outlined" style="width: 100%;">
-                            <RadzenDropDown Name="Tipo" TValue="TipoUsuario" Data="@tiposDisponiveis" @bind-Value="usuario.Tipo" style="width: 100%;" />
+                            <RadzenDropDown Name="Tipo" TValue="TipoUsuario" Data="@tiposDisponiveis" TextProperty="Value" ValueProperty="Key" @bind-Value="usuario.Tipo" style="width: 100%;" />
                         </RadzenFormField>
                     </RadzenColumn>
                 </RadzenRow>
@@ -86,7 +86,9 @@
 
     private UsuarioDto usuario = new() { Ativo = true, Tipo = TipoUsuario.Aluno };
     private bool carregando = false;
-    private readonly TipoUsuario[] tiposDisponiveis = Enum.GetValues<TipoUsuario>();
+    private readonly List<KeyValuePair<TipoUsuario, string>> tiposDisponiveis = Enum.GetValues<TipoUsuario>()
+        .Select(t => new KeyValuePair<TipoUsuario, string>(t, t.ToString()))
+        .ToList();
 
     protected override async Task OnInitializedAsync()
     {

--- a/TccManager.Client/Pages/Aluno/MeuTcc.razor
+++ b/TccManager.Client/Pages/Aluno/MeuTcc.razor
@@ -78,7 +78,7 @@
                                         </RadzenColumn>
                                         <RadzenColumn SizeMD="6" SizeXS="12">
                                             <RadzenFormField Text="Tipo de Entrega" Variant="Variant.Outlined" style="width: 100%;">
-                                                <RadzenDropDown TValue="TipoEntrega" Data="@tiposEntregaDisponiveis" @bind-Value="novaEntregaTipo" style="width: 100%;" />
+                                                <RadzenDropDown TValue="TipoEntrega" Data="@tiposEntregaDisponiveis" TextProperty="Value" ValueProperty="Key" @bind-Value="novaEntregaTipo" style="width: 100%;" />
                                             </RadzenFormField>
                                         </RadzenColumn>
                                         <RadzenColumn Size="12">
@@ -311,7 +311,9 @@
     private PropostaTccDto proposta = new();
     private string novaEntregaTitulo = "";
     private TipoEntrega novaEntregaTipo = TipoEntrega.Parcial;
-    private readonly TipoEntrega[] tiposEntregaDisponiveis = Enum.GetValues<TipoEntrega>();
+    private readonly List<KeyValuePair<TipoEntrega, string>> tiposEntregaDisponiveis = Enum.GetValues<TipoEntrega>()
+        .Select(t => new KeyValuePair<TipoEntrega, string>(t, t.ToString()))
+        .ToList();
     private Radzen.FileInfo? arquivoSelecionado;
     private List<Entrega>? entregasFeitas;
     private int? entregaSelecionadaParaFeedback;


### PR DESCRIPTION
## Summary
- `Admin/FormUsuario.razor` (Nivel de Acesso) e `Aluno/MeuTcc.razor` (Tipo de Entrega): o `RadzenDropDown` com `Data` como array de enum puro renderiza o valor selecionado (fechado) corretamente, mas a lista de opcoes aberta mostra o numero subjacente do enum (0, 1, 2, 3) em vez do nome (Aluno, Professor, Coordenador, Admin).
- Achado em teste manual no ambiente de dev, apos o merge do fix de seguranca do UsuarioController. Nao relacionado aquele fix.
- Corrigido trocando `Data` por `List<KeyValuePair<TEnum, string>>` com `TextProperty`/`ValueProperty` explicitos nos dois lugares (unicos dois no projeto com esse padrao).

## Test plan
- [x] `dotnet build`: 0 erros
- [x] `dotnet test`: 342/342 aprovados
- [x] Confirmado visualmente no navegador (ambiente de dev local): dropdown agora mostra Aluno/Professor/Coordenador/Admin